### PR TITLE
Fixed the default implementation of the MaterialWaterfall's callbacks

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialWaterfall.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialWaterfall.java
@@ -70,7 +70,7 @@ public class MaterialWaterfall extends ComplexWidget {
     protected void onLoad() {
         super.onLoad();
         if(openCallback == null && closeCallback == null) {
-            final Runnable openCallback = new Runnable() {
+            openCallback = new Runnable() {
                 @Override
                 public void run() {
                     for(Widget w : getChildren()){
@@ -78,7 +78,7 @@ public class MaterialWaterfall extends ComplexWidget {
                     }
                 }
             };
-            final Runnable closeCallback = new Runnable() {
+            closeCallback = new Runnable() {
                 @Override
                 public void run() {
                     for(Widget w : getChildren()){


### PR DESCRIPTION
Fixed the default implementation of the MaterialWaterfall's show and hide callbacks that was incorrectly declared in local scope instead of using the class scoped variables. This resulted in no callbacks set on MaterialWaterfall which caused an error in the browser.