### PR TITLE
The opening animation of the Cut Out is now handled by a CSS transition instead of an animation.

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialCutOut.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialCutOut.java
@@ -83,6 +83,12 @@ import com.google.gwt.user.client.ui.Widget;
  * <h3>Custom styling:</h3> You use change the cut out style by using the
  * <code>material-cutout</code> class, and <code>material-cutout-focus</code>
  * class for the focus box.
+ * 
+ * <h3>Notice:</h3>On some iOS devices, on mobile Safari, the CutOut may not open when the
+ * {@link #setCircle(boolean)} is set to <code>true</code>. This is because of problems on Safari
+ * with box-shadows over rounded borders. To avoid this issue you can disable the circle. Check the 
+ * <a href="https://github.com/GwtMaterialDesign/gwt-material/issues/227">issue 227</a> for details.
+ * 
  *
  * @author gilberto-torrezan
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/snapshot/#cutouts">Material SubHeaders</a>


### PR DESCRIPTION
The opening animation of the Cut Out is now handled by a CSS transition instead of a CSS animation. This reduces the complexity of the component and increases its portability.

Also added a field to allow the user to configure the radius size of the background of the Cut Out.

Also helping with the bug https://github.com/GwtMaterialDesign/gwt-material/issues/227.