### PR TITLE
Fixing visibility reduction error of public method

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialAutoComplete.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialAutoComplete.java
@@ -627,7 +627,7 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
             return this.suggestionPopup.isAnimationEnabled();
         }
 
-        private boolean isSuggestionListShowing() {
+        public boolean isSuggestionListShowing() {
             return this.suggestionPopup.isShowing();
         }
 


### PR DESCRIPTION
Using GWT Material Design 1.5-SNAPSHOT, caused by:

```java
// public static class MaterialAutoComplete extends SuggestBox.SuggestionDisplay
private boolean isSuggestionListShowing() {
    return this.suggestionPopup.isShowing();
}
```

Which is conflicting with:

```java
// public abstract static class SuggestBox.SuggestionDisplay
public boolean isSuggestionListShowing() {
  return false;
}
```

from GWT 2.8.0; giving the compile error output:

```
[INFO] Compiling module com.mahlzeit.client.ClientEntryPoint
[INFO]    Tracing compile failure path for type 'gwt.material.design.addins.client.ui.MaterialAutoComplete'
[INFO]       [ERROR] Errors in 'jar:file:/C:/Users/Stefan/.m2/repository/com/github/gwtmaterialdesign/gwt-material-addins/1.5-SNAPSHOT/gwt-material-addins-1.5-SNAPSHOT.jar!/gwt/material/design/addins/client/ui/MaterialAutoComplete.java'
[INFO]          [ERROR] Line 630: Cannot reduce the visibility of the inherited method from SuggestBox.SuggestionDisplay
```