### PR TITLE
MaterialTimePicker now implements HasValue<Date>

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -350,7 +350,7 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
         }
         
         if(this.time == time) {
-            return;
+            return; // No change
         }
         
         this.time = time;

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -228,6 +228,9 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
             orientation: orientation,
             hour24: hour24,
             uniqueId: clockId,
+            beforeShow: function() {
+                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::beforeShow()();
+            },
             afterShow: function() {
                 that.@gwt.material.design.addins.client.ui.MaterialTimePicker::afterShow()();
             },
@@ -236,16 +239,24 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
                 var minutes = $wnd.jQuery('#' + clockId).find('.lolliclock-minutes').find('.lolliclock-time-new').html();
                 var suffix = $wnd.jQuery('#' + clockId).find('.lolliclock-am-pm').html();
                 var time =  hour + ':' + minutes + " " + suffix;
-                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::afterHide(*)(time);
+                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::afterHide(*)();
             }
         });
         $wnd.jQuery(e).blur();
     }-*/;
     
+    
     /**
      * Called after the lolliclock event <code>afterShow</code>.
      */
-    private void afterShow() {
+    protected void beforeShow() {
+        this.input.getElement().blur();
+    }
+    
+    /**
+     * Called after the lolliclock event <code>afterShow</code>.
+     */
+    protected void afterShow() {
         this.fireOpenEvent();
     }
         
@@ -256,17 +267,22 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
      *            The time given by lolliclock in 12-hours <code>hh:mm aa</code>
      *            format.
      */
-    private void afterHide(String time) {
+    protected void afterHide() {
         
-        DateTimeFormat hour12DateTimeFormat = DateTimeFormat.getFormat("hh:mm aa");
-        Date parsedDate = hour12DateTimeFormat.parse(time);
+        String timeString = this.getTime(this.input.getElement());
         
+        Date parsedDate = null;
+
         if(this.hour24 == true) {
             DateTimeFormat hour24DateTimeFormat = DateTimeFormat.getFormat("HH:mm");
-            time = hour24DateTimeFormat.format(parsedDate);
+            parsedDate = hour24DateTimeFormat.parse(timeString);
+        } else {
+            DateTimeFormat hour12DateTimeFormat = DateTimeFormat.getFormat("hh:mm aa");
+            parsedDate = hour12DateTimeFormat.parse(timeString);
         }
+        
         this.setValue(parsedDate);
-        this.fireCloseEvent(time);
+        this.fireCloseEvent();
     }
     
     private native String getTime(Element e)/*-{
@@ -288,7 +304,7 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
         return this.addHandler(handler, OpenEvent.getType());
     }
 
-    private void fireCloseEvent(String time) {
+    private void fireCloseEvent() {
         CloseEvent.fire(this, this.time);
     }
 
@@ -327,12 +343,18 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
     @Override
     public void setValue(Date time, boolean fireEvents) {
         
-        if(this.time.equals(time)) {
+        if(this.time != null) {
+            if(this.time.equals(time)) {
+                return;
+            }
+        }
+        
+        if(this.time == time) {
             return;
         }
         
         this.time = time;
-        
+             
         if(fireEvents == true) {
             this.fireValueChangeEvent();
         }

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -1,5 +1,7 @@
 package gwt.material.design.addins.client.ui;
 
+import java.util.Date;
+
 /*
  * #%L
  * GwtMaterial
@@ -22,9 +24,19 @@ package gwt.material.design.addins.client.ui;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.logical.shared.*;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.event.logical.shared.HasCloseHandlers;
+import com.google.gwt.event.logical.shared.HasOpenHandlers;
+import com.google.gwt.event.logical.shared.OpenEvent;
+import com.google.gwt.event.logical.shared.OpenHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.HasValue;
+
 import gwt.material.design.client.base.HasError;
 import gwt.material.design.client.base.HasOrientation;
 import gwt.material.design.client.base.HasPlaceholder;
@@ -55,60 +67,68 @@ import gwt.material.design.client.ui.MaterialPanel;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#timepickers">Material Pickers</a>
  * @author kevzlou7979
  * @author Ben Dol
+ * @author silentsnooc
  */
 //@formatter:on
-public class MaterialTimePicker extends MaterialWidget implements HasError, HasPlaceholder, HasOrientation, HasCloseHandlers<String>, HasOpenHandlers<String> {
+public class MaterialTimePicker extends MaterialWidget implements HasError, HasPlaceholder, HasOrientation,
+        HasCloseHandlers<Date>, HasOpenHandlers<Date>, HasValue<Date> {
 
-    MaterialPanel panel = new MaterialPanel();
-    MaterialInput input = new MaterialInput();
+    /** Wraps the actual input. */
+    private MaterialPanel panel = new MaterialPanel();
+    
+    /** The input element for the time picker. */
+    private MaterialInput input = new MaterialInput();
+    
+    /** Label to display errors messages. */
+    private MaterialLabel lblError = new MaterialLabel();
 
-    private String time;
+    /** The current value held by the time picker. */
+    private Date time;
+    
+    private final ErrorMixin<MaterialTimePicker, MaterialLabel> errorMixin = new ErrorMixin<>(this, this.lblError, this.input);
+    
     private String placeholder;
     private boolean autoClose;
     private boolean hour24;
     private Orientation orientation = Orientation.PORTRAIT;
 
-    private MaterialLabel lblError = new MaterialLabel();
-
-    private final ErrorMixin<MaterialTimePicker, MaterialLabel> errorMixin = new ErrorMixin<>(this, lblError, input);
-
+    
     public MaterialTimePicker() {
         super(Document.get().createElement("div"));
-        input.setType(InputType.TEXT);
-        panel.add(input);
-        panel.add(lblError);
-        add(panel);
+        this.input.setType(InputType.TEXT);
+        this.panel.add(this.input);
+        this.panel.add(this.lblError);
+        this.add(this.panel);
     }
 
     @Override
     protected void onLoad() {
         super.onLoad();
-        input.getElement().setAttribute("type", "text");
-        initTimePicker();
+        this.input.getElement().setAttribute("type", "text");
+        this.initTimePicker();
     }
 
+    /**
+     * Side effects:
+     * <ul>
+     *   <li>Resets the time to <i>now<i></li>
+     *   <li>Clears erros/success message</li>
+     * </ul>
+     */
     public void reset() {
-        setTime("");
-        clearErrorOrSuccess();
+        this.setValue(new Date());
+        this.clearErrorOrSuccess();
     }
 
     /**
      * @return the time
      */
     public String getTime() {
-        return getTime(input.getElement());
-    }
-
-    /**
-     * @param time the time to set
-     */
-    public void setTime(String time) {
-        this.time = time;
-        input.getElement().setAttribute("value", time.toUpperCase());
+        return this.getTime(this.input.getElement());
     }
 
     public boolean isAutoClose() {
-        return autoClose;
+        return this.autoClose;
     }
 
     public void setAutoClose(boolean autoClose) {
@@ -117,43 +137,51 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
 
     /**
      * False (default) change to 24 hours system.
-     * @return
+     * 
+     * @return <code>false</code> in case 12 hours mode is set;
+     *         <code>true</code> otherwise.
      */
     public boolean isHour24() {
-        return hour24;
+        return this.hour24;
     }
 
+    /**
+     * 
+     * @param hour24
+     */
     public void setHour24(boolean hour24) {
         this.hour24 = hour24;
     }
 
     /**
-     * @return the placeholder
+     * @return The placeholder text.
      */
     @Override
     public String getPlaceholder() {
-        return placeholder;
+        return this.placeholder;
     }
 
     /**
-     * @param placeholder the placeholder to set
+     * @param placeholder
+     *            The placeholder text to set.
      */
     @Override
     public void setPlaceholder(String placeholder) {
         this.placeholder = placeholder;
-        input.getElement().setAttribute("placeholder", placeholder);
+        this.input.getElement().setAttribute("placeholder", placeholder);
     }
 
     /**
-     * @return the orientation
+     * @return The orientation.
      */
     @Override
     public Orientation getOrientation() {
-        return orientation;
+        return this.orientation;
     }
 
     /**
-     * @param orientation the orientation to set : can be Horizontal or Vertical
+     * @param orientation
+     *            The orientation to set: Can be Horizontal or Vertical.
      */
     @Override
     public void setOrientation(Orientation orientation) {
@@ -162,23 +190,37 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
 
     @Override
     public void setError(String error) {
-        errorMixin.setError(error);
+        this.errorMixin.setError(error);
     }
 
     @Override
     public void setSuccess(String success) {
-        errorMixin.setSuccess(success);
+        this.errorMixin.setSuccess(success);
     }
 
     @Override
     public void clearErrorOrSuccess() {
-        errorMixin.clearErrorOrSuccess();
+        this.errorMixin.clearErrorOrSuccess();
     }
 
     public void initTimePicker() {
-        initTimePicker(DOM.createUniqueId(), input.getElement(), getOrientation().getCssName(), isAutoClose(), isHour24());
+        this.initTimePicker(DOM.createUniqueId(), this.input.getElement(), this.getOrientation().getCssName(), this.isAutoClose(), this.isHour24());
     }
 
+    /**
+     * 
+     * @param clockId
+     *            The clock id for the lolliclock.
+     * @param e
+     *            The HTML element serving as container for textual content.
+     * @param orientation
+     *            The initial orientation.
+     * @param autoClose
+     *            Autoclose <code>true</code> or <code>false</code>
+     * @param hour24
+     *            Set this <true>true</code> for a 24 hours clock;
+     *            <code>false</code> otherwise.
+     */
     protected native void initTimePicker(String clockId, Element e, String orientation, boolean autoClose, boolean hour24) /*-{
         var that = this;
         $wnd.jQuery(e).lolliclock({
@@ -187,53 +229,110 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
             hour24: hour24,
             uniqueId: clockId,
             afterShow: function() {
-                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::fireOpenEvent()();
+                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::afterShow()();
             },
-            beforeHide: function() {
+            afterHide: function() {
                 var hour = $wnd.jQuery('#' + clockId).find('.lolliclock-hours').find('.lolliclock-time-new').html();
                 var minutes = $wnd.jQuery('#' + clockId).find('.lolliclock-minutes').find('.lolliclock-time-new').html();
                 var suffix = $wnd.jQuery('#' + clockId).find('.lolliclock-am-pm').html();
                 var time =  hour + ':' + minutes + " " + suffix;
-                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::fireCloseEvent(*)(time);
+                that.@gwt.material.design.addins.client.ui.MaterialTimePicker::afterHide(*)(time);
             }
         });
         $wnd.jQuery(e).blur();
     }-*/;
-
+    
+    /**
+     * Called after the lolliclock event <code>afterShow</code>.
+     */
+    private void afterShow() {
+        this.fireOpenEvent();
+    }
+        
+    /**
+     * Called after the lolliclock event <code>afterHide</code>.
+     * 
+     * @param time
+     *            The time given by lolliclock in 12-hours <code>hh:mm aa</code>
+     *            format.
+     */
+    private void afterHide(String time) {
+        
+        DateTimeFormat hour12DateTimeFormat = DateTimeFormat.getFormat("hh:mm aa");
+        Date parsedDate = hour12DateTimeFormat.parse(time);
+        
+        if(this.hour24 == true) {
+            DateTimeFormat hour24DateTimeFormat = DateTimeFormat.getFormat("HH:mm");
+            time = hour24DateTimeFormat.format(parsedDate);
+        }
+        this.setValue(parsedDate);
+        this.fireCloseEvent(time);
+    }
+    
     private native String getTime(Element e)/*-{
         return $wnd.jQuery(e).val();
     }-*/;
 
     @Override
     public void setEnabled(boolean enabled) {
-        input.setEnabled(enabled);
+        this.input.setEnabled(enabled);
     }
 
     @Override
-    public HandlerRegistration addCloseHandler(CloseHandler<String> handler) {
-        return addHandler(handler, CloseEvent.getType());
+    public HandlerRegistration addCloseHandler(CloseHandler<Date> handler) {
+        return this.addHandler(handler, CloseEvent.getType());
     }
 
     @Override
-    public HandlerRegistration addOpenHandler(OpenHandler<String> handler) {
-        return addHandler(handler, OpenEvent.getType());
+    public HandlerRegistration addOpenHandler(OpenHandler<Date> handler) {
+        return this.addHandler(handler, OpenEvent.getType());
     }
 
     private void fireCloseEvent(String time) {
-        CloseEvent.fire(this, time);
+        CloseEvent.fire(this, this.time);
     }
 
     private void fireOpenEvent() {
-        OpenEvent.fire(this, time);
+        OpenEvent.fire(this, this.time);
+    }
+    
+    private void fireValueChangeEvent() {
+        ValueChangeEvent.fire(this, this.time);
     }
 
     @Override
     public void clear() {
-        clearTimePickerValue(input.getElement());
+        this.clearTimePickerValue(this.input.getElement());
     }
 
     private native void clearTimePickerValue(Element e) /*-{
         $wnd.jQuery(e).val('');
     }-*/;
+    
+    @Override
+    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<Date> handler) {
+        return this.addHandler(handler, ValueChangeEvent.getType());
+    }
+
+    @Override
+    public Date getValue() {
+        return this.time;
+    }
+
+    @Override
+    public void setValue(Date time) {
+        this.time = time;
+        this.fireValueChangeEvent();
+    }
+
+    @Override
+    public void setValue(Date time, boolean fireEvents) {
+        
+        this.time = time;
+        
+        if(fireEvents == true) {
+            this.fireValueChangeEvent();
+        }
+    }
 
 }

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -321,12 +321,21 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
 
     @Override
     public void setValue(Date time) {
+        
+        if(this.time.equals(time)) {
+            return;
+        }
+
         this.time = time;
         this.fireValueChangeEvent();
     }
 
     @Override
     public void setValue(Date time, boolean fireEvents) {
+        
+        if(this.time.equals(time)) {
+            return;
+        }
         
         this.time = time;
         

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -2,8 +2,6 @@ package gwt.material.design.addins.client.ui;
 
 import java.util.Date;
 
-import com.google.gwt.dom.builder.shared.InputBuilder;
-
 /*
  * #%L
  * GwtMaterial
@@ -26,7 +24,6 @@ import com.google.gwt.dom.builder.shared.InputBuilder;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.HasCloseHandlers;
@@ -39,8 +36,6 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasValue;
-import com.google.gwt.user.client.ui.TextBox;
-import com.google.gwt.user.client.ui.ValueBox;
 
 import gwt.material.design.client.base.HasError;
 import gwt.material.design.client.base.HasOrientation;
@@ -73,7 +68,6 @@ import gwt.material.design.client.ui.MaterialPanel;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#timepickers">Material Pickers</a>
  * @author kevzlou7979
  * @author Ben Dol
- * @author silentsnooc
  */
 //@formatter:on
 public class MaterialTimePicker extends MaterialWidget implements HasError, HasPlaceholder, HasOrientation,
@@ -285,13 +279,19 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
         String timeString = this.getTime(this.input.getElement());
         
         Date parsedDate = null;
-
-        if(this.hour24 == true) {
-            DateTimeFormat hour24DateTimeFormat = DateTimeFormat.getFormat("HH:mm");
-            parsedDate = hour24DateTimeFormat.parse(timeString);
-        } else {
-            DateTimeFormat hour12DateTimeFormat = DateTimeFormat.getFormat("hh:mm aa");
-            parsedDate = hour12DateTimeFormat.parse(timeString);
+        
+        if(timeString.equals("") == false && timeString != null) {
+            try {
+                if(this.hour24 == true) {
+                    DateTimeFormat hour24DateTimeFormat = DateTimeFormat.getFormat("HH:mm");
+                    parsedDate = hour24DateTimeFormat.parse(timeString);
+                } else {
+                    DateTimeFormat hour12DateTimeFormat = DateTimeFormat.getFormat("hh:mm aa");
+                    parsedDate = hour12DateTimeFormat.parse(timeString);
+                }
+            } catch(Exception e) {
+                // silently catch parse errors
+            }
         }
         
         this.setValue(parsedDate);

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -321,13 +321,7 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
 
     @Override
     public void setValue(Date time) {
-        
-        if(this.time.equals(time)) {
-            return;
-        }
-
-        this.time = time;
-        this.fireValueChangeEvent();
+       this.setValue(time, true);
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -2,6 +2,8 @@ package gwt.material.design.addins.client.ui;
 
 import java.util.Date;
 
+import com.google.gwt.dom.builder.shared.InputBuilder;
+
 /*
  * #%L
  * GwtMaterial
@@ -24,6 +26,7 @@ import java.util.Date;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.HasCloseHandlers;
@@ -36,12 +39,15 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.ValueBox;
 
 import gwt.material.design.client.base.HasError;
 import gwt.material.design.client.base.HasOrientation;
 import gwt.material.design.client.base.HasPlaceholder;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.base.mixin.ErrorMixin;
+import gwt.material.design.client.base.mixin.ToggleStyleMixin;
 import gwt.material.design.client.constants.InputType;
 import gwt.material.design.client.constants.Orientation;
 import gwt.material.design.client.ui.MaterialInput;
@@ -84,6 +90,9 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
 
     /** The current value held by the time picker. */
     private Date time;
+    
+    /** */
+    private ToggleStyleMixin<MaterialInput> validMixin = new ToggleStyleMixin<>(this.input, "valid");
     
     private final ErrorMixin<MaterialTimePicker, MaterialLabel> errorMixin = new ErrorMixin<>(this, this.lblError, this.input);
     
@@ -253,8 +262,8 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
         
         this.input.getElement().blur();
 
-        // Add 'valid' for visual feedback.
-        this.input.getElement().setClassName("valid");
+        // Add class 'valid' for visual feedback.
+        this.validMixin.setOn(true);
     }
     
     /**
@@ -285,13 +294,10 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
             parsedDate = hour12DateTimeFormat.parse(timeString);
         }
         
-        // Remove 'valid' after hide.
-        this.panel.getElement().removeAttribute("valid");
-        
         this.setValue(parsedDate);
         
-        // Remove 'valid' after hide.
-        this.panel.getElement().removeClassName("valid");
+        // Remove class 'valid' after hide.
+        this.validMixin.setOn(false);
         
         this.fireCloseEvent();
     }
@@ -365,10 +371,26 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
         }
         
         this.time = time;
+        
+        String timeString = null;
+        
+        if(this.hour24 == true) {
+            DateTimeFormat hour24DateTimeFormat = DateTimeFormat.getFormat("HH:mm");
+            timeString = hour24DateTimeFormat.format(time);
+        } else {
+            DateTimeFormat hour12DateTimeFormat = DateTimeFormat.getFormat("hh:mm aa");
+            timeString = hour12DateTimeFormat.format(time);
+        }
+        
+        this.setValue(this.input.getElement(), timeString);
              
         if(fireEvents == true) {
             this.fireValueChangeEvent();
         }
     }
+    
+    private native void setValue(Element e, String time) /*-{
+        $wnd.jQuery(e).val(time);
+    }-*/;
 
 }

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -51,7 +51,7 @@ import gwt.material.design.client.ui.MaterialPanel;
 //@formatter:off
 
 /**
- * Material Time Picker -  provide a simple way to select a single value from a pre-determined set.
+ * Material Time Picker - provide a simple way to select a single value from a pre-determined set.
  *
  * <h3>XML Namespace Declaration</h3>
  * <pre>
@@ -62,7 +62,7 @@ import gwt.material.design.client.ui.MaterialPanel;
  *
  * <h3>UiBinder Usage:</h3>
  * <pre>
- *{@code <m.addins:MaterialTimePicker placeholder="Time Arrival" />
+ * {@code <m.addins:MaterialTimePicker placeholder="Time Arrival" />}
  * </pre>
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#timepickers">Material Pickers</a>
  * @author kevzlou7979

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialTimePicker.java
@@ -250,7 +250,11 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
      * Called after the lolliclock event <code>afterShow</code>.
      */
     protected void beforeShow() {
+        
         this.input.getElement().blur();
+        
+        // Add 'valid' for visual feedback.
+        this.input.getElement().setClassName("valid");
     }
     
     /**
@@ -282,6 +286,10 @@ public class MaterialTimePicker extends MaterialWidget implements HasError, HasP
         }
         
         this.setValue(parsedDate);
+        
+        // Remove 'valid' after hide.
+        this.panel.getElement().removeClassName("valid");
+        
         this.fireCloseEvent();
     }
     


### PR DESCRIPTION
`MaterialTimePicker `now implements `HasValue<Date>`. Also got rid of the private field `String time` and replaced it by `Date time`. and did some minor refactoring and added some documentation.

The `ValueChangeEvent` can now be utilized:
```java
MaterialTimePicker timePicker = new MaterialTimePicker();
timePicker.setHour24(true);
timePicker.addValueChangeHandler(new ValueChangeHandler<Date>() {
	@Override
	public void onValueChange(ValueChangeEvent<Date> event) {
		DateTimeFormat dtf = DateTimeFormat.getFormat("HH:mm");
		Date time = event.getValue();
		LOGGER.fine("MaterialTimePicker value changed to: " + dtf.format(time));
	}
});
timePicker.setValue(new Date());
```

PS: I am sorry for this insane amount of commits here XD