### PR TITLE
New component: MaterialCameraCapture.

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/base/HasCameraCaptureHandlers.java
+++ b/src/main/java/gwt/material/design/addins/client/base/HasCameraCaptureHandlers.java
@@ -1,0 +1,43 @@
+package gwt.material.design.addins.client.base;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.addins.client.events.CameraCaptureHandler;
+import gwt.material.design.addins.client.ui.MaterialCameraCapture;
+
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.event.shared.HasHandlers;
+
+/**
+ * Interface that defines widgets that contains {@link CameraCaptureHandler}s.
+ * 
+ * @author gilberto-torrezan
+ * 
+ * @see MaterialCameraCapture
+ */
+public interface HasCameraCaptureHandlers extends HasHandlers {
+
+    /**
+     * Adds a CameraCaptureHandler.
+     */
+    HandlerRegistration addCameraCaptureHandler(CameraCaptureHandler handler);
+
+}

--- a/src/main/java/gwt/material/design/addins/client/events/CameraCaptureEvent.java
+++ b/src/main/java/gwt/material/design/addins/client/events/CameraCaptureEvent.java
@@ -1,0 +1,104 @@
+package gwt.material.design.addins.client.events;
+
+import gwt.material.design.addins.client.base.HasCameraCaptureHandlers;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.addins.client.ui.MaterialCameraCapture;
+
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * <p>
+ * Event that holds informartion about the state of a {@link HasCameraCaptureHandlers}, such
+ * as {@link MaterialCameraCapture}.
+ * </p>
+ * <p>
+ * When the stream has started, after the user allows the browser to use the camera, an event 
+ * with {@link CaptureStatus#STARTED} is raised. If the stream is paused, an event with
+ * {@link CaptureStatus#PAUSED} is raised. If the user doesn't allow the browser to use the camera,
+ * or if any other error occurs, an event with  {@link CaptureStatus#ERRORED} is raised, with the 
+ * {@link #getErrorMessage()} set.
+ * </p>
+ * 
+ * @author gilberto-torrezan
+ */
+public class CameraCaptureEvent extends GwtEvent<CameraCaptureHandler> {
+
+    private static Type<CameraCaptureHandler> TYPE = new Type<CameraCaptureHandler>();
+
+    public enum CaptureStatus {
+        STARTED, PAUSED, ERRORED;
+    }
+
+    private final CaptureStatus captureStatus;
+    private final String errorMessage;
+
+    private CameraCaptureEvent(CaptureStatus captureStatus, String errorMessage) {
+        this.captureStatus = captureStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Fires an event with the {@link CaptureStatus}.
+     */
+    public static <T> void fire(HasCameraCaptureHandlers source, CaptureStatus status) {
+        CameraCaptureEvent event = new CameraCaptureEvent(status, null);
+        source.fireEvent(event);
+    }
+
+    /**
+     * Fires an event with the {@link CaptureStatus#ERRORED} status and the error message.
+     */
+    public static <T> void fire(HasCameraCaptureHandlers source, String errorMessage) {
+        CameraCaptureEvent event = new CameraCaptureEvent(CaptureStatus.ERRORED, errorMessage);
+        source.fireEvent(event);
+    }
+
+    /**
+     * Returns the {@link CaptureStatus} that raised this event.
+     */
+    public CaptureStatus getCaptureStatus() {
+        return captureStatus;
+    }
+
+    /**
+     * Returns the error message when the {@link #getCaptureStatus()} is {@link CaptureStatus#ERRORED}.
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public com.google.gwt.event.shared.GwtEvent.Type<CameraCaptureHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    public static Type<CameraCaptureHandler> getType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(CameraCaptureHandler handler) {
+        handler.onCameraCaptureChange(this);
+    }
+
+}

--- a/src/main/java/gwt/material/design/addins/client/events/CameraCaptureHandler.java
+++ b/src/main/java/gwt/material/design/addins/client/events/CameraCaptureHandler.java
@@ -1,0 +1,41 @@
+package gwt.material.design.addins.client.events;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.addins.client.ui.MaterialCameraCapture;
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Handler for {@link CameraCaptureEvent}s.
+ * 
+ * @author gilberto-torrezan
+ * 
+ * @see MaterialCameraCapture
+ */
+public interface CameraCaptureHandler extends EventHandler {
+
+    /**
+     * Fired when there's a change on the state of the camera capture.
+     */
+    void onCameraCaptureChange(CameraCaptureEvent event);
+
+}

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialCameraCapture.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialCameraCapture.java
@@ -1,0 +1,251 @@
+package gwt.material.design.addins.client.ui;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.addins.client.base.HasCameraCaptureHandlers;
+import gwt.material.design.addins.client.events.CameraCaptureEvent;
+import gwt.material.design.addins.client.events.CameraCaptureEvent.CaptureStatus;
+import gwt.material.design.addins.client.events.CameraCaptureHandler;
+import gwt.material.design.client.base.MaterialWidget;
+
+import com.google.gwt.canvas.client.Canvas;
+import com.google.gwt.dom.client.CanvasElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.VideoElement;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * <p>
+ * MaterialCameraCapture is a widget that captures the video stream from the camera, using the
+ * HTML5 {@code MediaDevices.getUserMedia()} (Streams API). This widget can capture images from the video, to allow
+ * the upload to the server of photos from the camera.
+ * </p>
+ * <p>
+ * Note that this widget only works on pages served by a secure protocol (HTTPS). For the browser compatibility,
+ * access <a href="http://caniuse.com/#feat=stream">http://caniuse.com/#feat=stream</a>
+ * </p>
+ * 
+ * @author gilberto-torrezan
+ */
+public class MaterialCameraCapture extends MaterialWidget implements HasCameraCaptureHandlers {
+
+    protected boolean pauseOnUnload = true;
+
+    public MaterialCameraCapture() {
+        super(Document.get().createVideoElement());
+    }
+
+    /**
+     * Captures the current frame of the video to an image data URL. It's the same as calling
+     * {@link #captureToDataURL(String)} using "image/png".
+     * 
+     * @return The Data URL of the captured image, which can be used as "src" on an "img" element
+     * or sent to the server
+     */
+    public String captureToDataURL() {
+        return captureToDataURL("image/png");
+    }
+
+    /**
+     * Captures the current frame of the video to an image data URL.
+     * 
+     * @param mimeType The type of the output image, such as "image/png" or "image/jpeg".
+     * 
+     * @return The Data URL of the captured image, which can be used as "src" on an "img" element
+     * or sent to the server
+     */
+    public String captureToDataURL(String mimeType) {
+        return nativeCaptureToDataURL(Canvas.createIfSupported().getCanvasElement(), getElement(), mimeType);
+    }
+
+    @Override
+    protected void onLoad() {
+        VideoElement el = getElement().cast();
+        if (el.getSrc() == null || el.isPaused()) {
+            play();
+        }
+    }
+
+    @Override
+    protected void onUnload() {
+        if (pauseOnUnload) {
+            pause();
+        }
+    }
+
+    /**
+     * <p>
+     * Starts the video stream from the camera. This is called when the component is loaded.
+     * Use {@link CameraCaptureHandler}s to be notified when the stream actually starts or if
+     * an error occurs.
+     * </p>
+     * <p>
+     * At this point the user is requested by the browser to allow the application to use the camera.
+     * If the user doesn't allow it, an error is notified to the {@link CameraCaptureHandler}s.
+     * </p>
+     */
+    public void play() {
+        if (!isSupported()) {
+            return;
+        }
+        VideoElement el = getElement().cast();
+        if (el.getSrc() == null) {
+            nativePlay(getElement());
+        } else {
+            el.play();
+        }
+    }
+    
+    /**
+     * Restarts the video stream from the camera. 
+     * The user is requested again by the browser to allow the application to use the camera.
+     */
+    public void restart() {
+        if (!isSupported()) {
+            return;
+        }
+        nativePlay(getElement());
+    }
+
+    /**
+     * Pauses the video stream from the camera.
+     */
+    public void pause() {
+        VideoElement el = getElement().cast();
+        el.pause();
+        onCameraCapturePause();
+    }
+
+    /**
+     * Sets if the camera capture should pause when the widget is unloaded.
+     * The default is <code>true</code>. 
+     */
+    public void setPauseOnUnload(boolean pauseOnUnload) {
+        this.pauseOnUnload = pauseOnUnload;
+    }
+
+    /**
+     * Returns if the camera capture should pause when the widget is unloaded.
+     * The default is <code>true</code>.
+     */
+    public boolean isPauseOnUnload() {
+        return pauseOnUnload;
+    }
+
+    /**
+     * Native call to the streams API
+     */
+    protected native void nativePlay(Element video)/*-{
+       var navigator = $wnd.navigator;
+       var widget = this;
+       
+       var onSuccess = function(stream) {
+           var vendorURL = $wnd.URL || $wnd.webkitURL;
+           video.src = vendorURL.createObjectURL(stream);
+           video.play();
+           widget.@com.feelvision.client.components.MaterialCameraCapture::onCameraCaptureLoad()();
+       };
+       
+       var onFailure = function(err) {
+           console.log("MaterialCameraCapture: An error occured! " + err);
+           widget.@com.feelvision.client.components.MaterialCameraCapture::onCameraCaptureError(Ljava/lang/String;)(err.message);
+       };
+       
+       //using premisses
+       if (navigator.mediaDevices.getUserMedia){
+           var p = navigator.mediaDevices.getUserMedia({video: true, audio: false});
+           p.then(onSuccess);
+           //workaround for the catch keyword. See https://groups.google.com/forum/#!topic/google-web-toolkit/t1KGh-7KL-k
+           p["catch"](onFailure);
+       }
+       else {
+           navigator.getMedia = (navigator.getUserMedia ||
+           navigator.webkitGetUserMedia ||
+           navigator.mozGetUserMedia ||
+           navigator.msGetUserMedia);
+           navigator.getMedia({video: true, audio: false}, onSuccess, onFailure);
+       }
+    }-*/;
+
+    /**
+     * Native call to capture the frame of the video stream.
+     */
+    protected native String nativeCaptureToDataURL(CanvasElement canvas, Element video, String mimeType)/*-{
+        var width = video.videoWidth;
+        var height = video.videoHeight;
+        
+        if (isNaN(width) || isNaN(height)) {
+            width = video.clientWidth;
+            height = video.clientHeight;
+        }
+        
+        canvas.width = width;
+        canvas.height = height;
+        
+        var context = canvas.getContext('2d');
+        context.drawImage(video, 0, 0, width, height);
+        
+        var data = canvas.toDataURL(mimeType);
+        return data;
+    }-*/;
+
+    /**
+     * Tests if the browser supports the Streams API. This should be called before creating any
+     * MaterialCameraCapture widgets to avoid errors on the browser.
+     * 
+     * @return <code>true</code> if the browser supports this widget, <code>false</code> otherwise 
+     */
+    public static native boolean isSupported()/*-{
+      return !!(navigator.mediaDevices.getUserMedia ||
+          navigator.getUserMedia ||
+          navigator.webkitGetUserMedia ||
+          navigator.mozGetUserMedia ||
+          navigator.msGetUserMedia);
+    }-*/;
+
+    /**
+     * Called by the component when the stream has started.
+     */
+    protected void onCameraCaptureLoad() {
+        CameraCaptureEvent.fire(this, CaptureStatus.STARTED);
+    }
+
+    /**
+     * Called  by the component when the stream has paused.
+     */
+    protected void onCameraCapturePause() {
+        CameraCaptureEvent.fire(this, CaptureStatus.PAUSED);
+    }
+
+    /**
+     *  Called by the component when the stream when an error occurs.
+     */
+    protected void onCameraCaptureError(String error) {
+        CameraCaptureEvent.fire(this, error);
+    }
+
+    @Override
+    public HandlerRegistration addCameraCaptureHandler(CameraCaptureHandler handler) {
+        return addHandler(handler, CameraCaptureEvent.getType());
+    }
+
+}

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialCameraCapture.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialCameraCapture.java
@@ -39,8 +39,43 @@ import com.google.gwt.event.shared.HandlerRegistration;
  * HTML5 {@code MediaDevices.getUserMedia()} (Streams API). This widget can capture images from the video, to allow
  * the upload to the server of photos from the camera.
  * </p>
+ * 
+ * <h3>UiBinder Usage:</h3>
+ * <p><pre>
+ * {@code
+ * <m.addins:MaterialCameraCapture ui:field="camera" />
+ * }
+ * </pre></p>
+ * 
+ * <h3>Java Usage:</h3>
+ * <p><pre>
+ *  if (MaterialCameraCapture.isSupported()){
+ *      MaterialCameraCapture camera = new MaterialCameraCapture();
+ *      camera.addCameraCaptureHandler(new CameraCaptureHandler() {
+ *          {@literal @}Override
+ *          public void onCameraCaptureChange(CameraCaptureEvent event) {
+ *              if (event.getCaptureStatus() == CaptureStatus.ERRORED){
+ *                  Window.alert("Error on starting the camera capture: " + event.getErrorMessage());
+ *                  ((MaterialCameraCapture)event.getSource()).removeFromParent();
+ *              }
+ *          }
+ *      });
+ *      add(camera); //adds to the layout
+ *  }
+ *  else {
+ *      Window.alert("Sorry, your browser doesn't support the camera capture.");
+ *  }
+ * </pre></p>
+ *
+ * <h3>Styling:</h3>
  * <p>
- * Note that this widget only works on pages served by a secure protocol (HTTPS). For the browser compatibility,
+ * To limit the width of the camera capture widget on mobile devices, you can use {@code max-width: 100%} on the widget.
+ * The browser will take care of the aspect ratio of the video.
+ * </p>
+ * 
+ * <h3>Notice:</h3>
+ * <p>
+ * This widget only works on pages served by a secure protocol (HTTPS). For the browser compatibility,
  * access <a href="http://caniuse.com/#feat=stream">http://caniuse.com/#feat=stream</a>
  * </p>
  * 
@@ -105,6 +140,7 @@ public class MaterialCameraCapture extends MaterialWidget implements HasCameraCa
      */
     public void play() {
         if (!isSupported()) {
+            onCameraCaptureError("MaterialCameraCapture is not supported in this browser.");
             return;
         }
         VideoElement el = getElement().cast();
@@ -121,6 +157,7 @@ public class MaterialCameraCapture extends MaterialWidget implements HasCameraCa
      */
     public void restart() {
         if (!isSupported()) {
+            onCameraCaptureError("MaterialCameraCapture is not supported in this browser.");
             return;
         }
         nativePlay(getElement());


### PR DESCRIPTION
MaterialCameraCapture is a widget that captures the video stream from the camera, using the
HTML5 Streams API. This widget can capture images from the video, to allow the upload to the server of photos from the camera.

You can see it in action at https://feel-vision.appspot.com/