### PR TITLE
Changed how the MaterialStep interacts with the MaterialStepper.

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialStep.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialStep.java
@@ -20,14 +20,9 @@ package gwt.material.design.addins.client.ui;
  * #L%
  */
 
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.ui.Widget;
 import gwt.material.design.addins.client.base.mixin.ActiveMixin;
 import gwt.material.design.client.base.HasActive;
+import gwt.material.design.client.base.HasAxis;
 import gwt.material.design.client.base.HasError;
 import gwt.material.design.client.base.HasTitle;
 import gwt.material.design.client.base.MaterialWidget;
@@ -35,6 +30,15 @@ import gwt.material.design.client.constants.Axis;
 import gwt.material.design.client.constants.IconType;
 import gwt.material.design.client.ui.MaterialIcon;
 import gwt.material.design.client.ui.html.Div;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.HasSelectionHandlers;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Widget;
 
 //@formatter:off
 
@@ -65,7 +69,7 @@ import gwt.material.design.client.ui.html.Div;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/snapshot/#steppers">Material Steppers</a>
  */
 // @formatter:on
-public class MaterialStep extends MaterialWidget implements HasActive, HasTitle, HasError, HasClickHandlers {
+public class MaterialStep extends MaterialWidget implements HasActive, HasTitle, HasError, HasAxis, HasSelectionHandlers<MaterialStep> {
 
     private int step;
     private String title;
@@ -85,7 +89,8 @@ public class MaterialStep extends MaterialWidget implements HasActive, HasTitle,
     private MaterialIcon iconError = new MaterialIcon(IconType.REPORT_PROBLEM);
     private MaterialIcon iconSuccess = new MaterialIcon(IconType.CHECK_CIRCLE);
     private final ActiveMixin<MaterialStep> activeMixin = new ActiveMixin<>(this);
-    private MaterialStepper stepper;
+    
+    private Axis axis = Axis.VERTICAL;
 
     public MaterialStep() {
         super(Document.get().createDivElement());
@@ -103,29 +108,18 @@ public class MaterialStep extends MaterialWidget implements HasActive, HasTitle,
         divLine.setStyleName("line");
         divTitle.setStyleName("title");
         divBody.setStyleName("body");
-    }
-
-    @Override
-    protected void onLoad() {
-        super.onLoad();
-        if(getParent() instanceof MaterialStepper){
-            stepper = (MaterialStepper) getParent();
-            if(stepper.getAxis() == Axis.HORIZONTAL){
-                conCircle.add(divTitle);
-                conCircle.add(divLine);
-                conCircle.add(divDescription);
-            }else{
-                conBody.insert(divTitle, 0);
-                conCircle.add(divLine);
-            }
-
-        }
-        conCircle.addClickHandler(new ClickHandler() {
+        
+        ClickHandler handler = new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                stepper.goToStep(step);
+                if (isEnabled() && isVisible()){
+                    SelectionEvent.fire(MaterialStep.this, MaterialStep.this);                    
+                }
             }
-        });
+        };
+        conCircle.addClickHandler(handler);
+        divTitle.addClickHandler(handler);
+        divDescription.addClickHandler(handler);
     }
 
     @Override
@@ -209,9 +203,33 @@ public class MaterialStep extends MaterialWidget implements HasActive, HasTitle,
     public Div getDivBody() {
         return divBody;
     }
+    
+    @Override
+    public void setAxis(Axis axis) {
+        if (axis == null){
+            axis = Axis.VERTICAL;
+        }
+        this.axis = axis;
+        switch (axis){
+        case HORIZONTAL:
+            conCircle.add(divTitle);
+            conCircle.add(divLine);
+            conCircle.add(divDescription);
+            break;
+        case VERTICAL:
+            conBody.insert(divTitle, 0);
+            conCircle.add(divLine);
+            break;
+        }
+    }
+    
+    @Override
+    public Axis getAxis() {
+        return axis;
+    }
 
     @Override
-    public HandlerRegistration addClickHandler(ClickHandler handler) {
-        return divCircle.addDomHandler(handler, ClickEvent.getType());
+    public HandlerRegistration addSelectionHandler(SelectionHandler<MaterialStep> handler) {
+        return this.addHandler(handler, SelectionEvent.getType());
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/ui/MaterialStepper.java
+++ b/src/main/java/gwt/material/design/addins/client/ui/MaterialStepper.java
@@ -20,9 +20,6 @@ package gwt.material.design.addins.client.ui;
  * #L%
  */
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.user.client.ui.Widget;
 import gwt.material.design.client.base.HasAxis;
 import gwt.material.design.client.base.HasError;
 import gwt.material.design.client.base.MaterialWidget;
@@ -33,6 +30,16 @@ import gwt.material.design.client.ui.animate.MaterialAnimator;
 import gwt.material.design.client.ui.animate.Transition;
 import gwt.material.design.client.ui.html.Div;
 import gwt.material.design.client.ui.html.Span;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.view.client.SelectionChangeEvent;
+import com.google.gwt.view.client.SelectionChangeEvent.Handler;
+import com.google.gwt.view.client.SelectionChangeEvent.HasSelectionChangedHandlers;
 
 //@formatter:off
 
@@ -65,12 +72,12 @@ import gwt.material.design.client.ui.html.Span;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/snapshot/#steppers">Material Steppers</a>
  */
 // @formatter:on
-public class MaterialStepper extends MaterialWidget implements HasAxis, HasError {
+public class MaterialStepper extends MaterialWidget implements HasAxis, HasError, SelectionHandler<MaterialStep>, HasSelectionChangedHandlers {
 
-    private int totalSteps = 0;
     private int currentStepIndex = 0;
     private Div divFeedback = new Div();
     private Span feedback = new Span();
+    private boolean stepSkippingAllowed = true;
 
     private final CssNameMixin<MaterialStepper, Axis> axisMixin = new CssNameMixin<>(this);
 
@@ -84,7 +91,16 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
     @Override
     protected void onLoad() {
         super.onLoad();
-        goToStep(1);
+        goToStep(currentStepIndex + 1);
+    }
+    
+    /**
+     * Specific method to add {@link MaterialStep}s to the stepper.
+     */
+    public void add(MaterialStep step) {
+        this.add((Widget)step);
+        step.setAxis(getAxis());
+        step.addSelectionHandler(this);
     }
 
     /**
@@ -102,10 +118,21 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
 
                 // next step
                 int nextStepIndex = getWidgetIndex(step) + 1;
-                MaterialStep nextStep = (MaterialStep) getWidget(nextStepIndex);
-                nextStep.setActive(true);
+                if (nextStepIndex >= 0){
+                    for(int i = nextStepIndex; i < getWidgetCount(); i++){
+                        w = getWidget(i);
+                        if (!(w instanceof MaterialStep)){
+                            continue;
+                        }
+                        MaterialStep nextStep = (MaterialStep) w;
+                        if (nextStep.isEnabled() && nextStep.isVisible()){
+                            nextStep.setActive(true);                    
+                            setCurrentStepIndex(i);
+                            break;
+                        }
+                    }
+                }
             }
-            currentStepIndex++;
         }
     }
 
@@ -121,21 +148,31 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
 
                 // next step
                 int prevStepIndex = getWidgetIndex(step) - 1;
-                MaterialStep prevStep = (MaterialStep) getWidget(prevStepIndex);
-                prevStep.setActive(true);
+                if (prevStepIndex >= 0){
+                    for(int i = prevStepIndex; i >= 0; i--){
+                        w = getWidget(i);
+                        if (!(w instanceof MaterialStep)){
+                            continue;
+                        }
+                        MaterialStep prevStep = (MaterialStep) w;
+                        if (prevStep.isEnabled() && prevStep.isVisible()){
+                            prevStep.setActive(true);                    
+                            setCurrentStepIndex(i);
+                            break;
+                        }
+                    }
+                }
             }
-            currentStepIndex--;
         }else{
             GWT.log("You have reach the minimum step.");
         }
     }
 
     /**
-     * Go to specific step manually by setting which step you want to go.
+     * Go to specific step manually by setting which step index you want to go.
      */
     public void goToStep(int step){
-        totalSteps = getWidgetCount();
-        for(int i = 0; i < totalSteps; i++){
+        for(int i = 0; i < getWidgetCount(); i++){
             Widget w = getWidget(i);
             if(w instanceof MaterialStep){
                 ((MaterialStep) w).setActive(false);
@@ -146,9 +183,45 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
         if(w instanceof MaterialStep){
             ((MaterialStep) w).setActive(true);
         }
-        currentStepIndex = step - 1;
+        setCurrentStepIndex(step - 1);
     }
 
+    /**
+     * Go to the specfic {@link MaterialStep}.
+     */
+    public void goToStep(MaterialStep step){
+        for(int i = 0; i < getWidgetCount(); i++){
+            Widget w = getWidget(i);
+            if(w instanceof MaterialStep){
+                MaterialStep materialStep = (MaterialStep) w;
+                boolean active = materialStep.equals(step);
+                materialStep.setActive(active);
+                if (active){
+                    setCurrentStepIndex(i);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Go to the step with the specified step id.
+     * 
+     * @see MaterialStep#getStep()
+     */
+    public void goToStepId(int id){
+        for(int i = 0; i < getWidgetCount(); i++){
+            Widget w = getWidget(i);
+            if(w instanceof MaterialStep){
+                MaterialStep materialStep = (MaterialStep) w;
+                boolean active = materialStep.getStep() == id;
+                materialStep.setActive(active);
+                if (active){
+                    setCurrentStepIndex(i);
+                }
+            }
+        }
+    }
+    
     /**
      * Reset the Stepper to initial step (first step).
      */
@@ -157,17 +230,30 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
         clearErrorOrSuccess();
     }
 
-    public void setCurrentStepIndex(int currentStepIndex) {
-        this.currentStepIndex = currentStepIndex;
+    /**
+     * Called internally when the index is changed. Fires a {@link SelectionChangeEvent}
+     * when the current index changes.
+     */
+    protected void setCurrentStepIndex(int currentStepIndex) {
+        if (this.currentStepIndex != currentStepIndex){
+            this.currentStepIndex = currentStepIndex;
+            SelectionChangeEvent.fire(this);            
+        }
     }
 
     public int getCurrentStepIndex() {
         return currentStepIndex;
     }
-
+    
     @Override
     public void setAxis(Axis axis) {
         axisMixin.setCssName(axis);
+        for(int i = 0; i < getWidgetCount(); i++){
+            Widget w = getWidget(i);
+            if(w instanceof MaterialStep){
+                ((MaterialStep) w).setAxis(axis);
+            }
+        }
     }
 
     @Override
@@ -179,7 +265,14 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
      * Gets the current step component.
      */
     public MaterialStep getCurrentStep() {
-        return (MaterialStep) getWidget(getCurrentStepIndex());
+        if(currentStepIndex >= getWidgetCount() - 1 || currentStepIndex < 0){
+            return null;
+        }
+        Widget w = getWidget(currentStepIndex);
+        if (w instanceof MaterialStep){
+            return (MaterialStep) w;
+        }
+        return null;
     }
 
     @Override
@@ -194,7 +287,7 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
 
     @Override
     public void clearErrorOrSuccess() {
-        for(int i = 0; i < totalSteps; i++){
+        for(int i = 0; i < getWidgetCount(); i++){
             Widget w = getWidget(i);
             if(w instanceof MaterialStep){
                 ((MaterialStep) w).clearErrorOrSuccess();
@@ -224,5 +317,36 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
      */
     public void hideFeedback() {
         divFeedback.removeFromParent();
+    }
+    
+    /**
+     * Sets whether the user is allowed to skip steps by clicking on the step title.
+     * The default is <code>true</code>. 
+     */
+    public void setStepSkippingAllowed(boolean stepSkippingAllowed) {
+        this.stepSkippingAllowed = stepSkippingAllowed;
+    }
+    
+    /**
+     * Returns whether the user is allowed to skip steps by clicking on the step title.
+     * The default is <code>true</code>.
+     */
+    public boolean isStepSkippingAllowed() {
+        return stepSkippingAllowed;
+    }
+    
+    /**
+     * Called when a step title is clicked.
+     */
+    @Override
+    public void onSelection(SelectionEvent<MaterialStep> event) {
+        if (stepSkippingAllowed){
+            goToStep(event.getSelectedItem());            
+        }
+    }
+
+    @Override
+    public HandlerRegistration addSelectionChangeHandler(Handler handler) {
+        return addHandler(handler, SelectionChangeEvent.getType());
     }
 }


### PR DESCRIPTION
Changed how the MaterialStep interacts with the MaterialStepper: the children no longer knows about the parent - they fire selection events that are handled by the parent.

Removed problems on `onLoad` methods, fixing #27.

Also added several utility methods to MaterialStepper, such as SelectionChangeHandling, mutliple ways to set the current step, and a flag allowing or not the user to skip steps.