### PR TITLE
MaterialWindow add/remove to rootpanel

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/masonry/MaterialMasonry.java
+++ b/src/main/java/gwt/material/design/addins/client/masonry/MaterialMasonry.java
@@ -74,7 +74,7 @@ public class MaterialMasonry extends MaterialRow {
     private MaterialWidget sizerDiv = new MaterialWidget(Document.get().createDivElement());
 
     public MaterialMasonry() {
-        setInitialClass("masonry-row");
+        setInitialClasses("masonry-row");
         sizerDiv.setWidth("8.3333%");
         sizerDiv.setStyleName("col-sizer");
         add(sizerDiv);

--- a/src/main/java/gwt/material/design/addins/client/window/MaterialWindow.java
+++ b/src/main/java/gwt/material/design/addins/client/window/MaterialWindow.java
@@ -39,8 +39,6 @@ import gwt.material.design.client.constants.IconType;
 import gwt.material.design.client.constants.WavesType;
 import gwt.material.design.client.ui.MaterialIcon;
 import gwt.material.design.client.ui.MaterialLink;
-import gwt.material.design.client.ui.animate.MaterialAnimator;
-import gwt.material.design.client.ui.animate.Transition;
 
 //@formatter:off
 
@@ -196,9 +194,11 @@ public class MaterialWindow extends MaterialWidget implements HasCloseHandlers<B
      * Open the window
      */
     public void openWindow() {
+        if (!this.isAttached()) {
+            RootPanel.get().add(this);
+        }
         this.open = false;
         OpenEvent.fire(this, true);
-        MaterialAnimator.animate(Transition.ZOOMIN, window, 0, 200);
         closeMixin.setOn(true);
     }
 
@@ -206,16 +206,13 @@ public class MaterialWindow extends MaterialWidget implements HasCloseHandlers<B
      * Close the window
      */
     public void closeWindow() {
+        if (this.isAttached()) {
+            this.removeFromParent();
+        }
         this.open = true;
         CloseEvent.fire(this, false);
-        Runnable callback = new Runnable() {
-            @Override
-            public void run() {
-                closeMixin.setOn(false);
-                RootPanel.get().getElement().getStyle().setCursor(Style.Cursor.DEFAULT);
-            }
-        };
-        MaterialAnimator.animate(Transition.ZOOMOUT, window, 0, callback);
+        closeMixin.setOn(false);
+        RootPanel.get().getElement().getStyle().setCursor(Style.Cursor.DEFAULT);
     }
 
     public String getToolbarColor() {


### PR DESCRIPTION
- Will add & remove itself to rootpanel.  Dialog widget no longer have to be added to a widget to be shown, will not break current implementations.  First time on open will be still be attached to the component, next time to the rootpanel.
- Removed the animation on window open/close, people could want to have different animations or no animation at all.