### PR TITLE
Window bug fix: on close crash, runnable is not a function

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/window/MaterialWindow.java
+++ b/src/main/java/gwt/material/design/addins/client/window/MaterialWindow.java
@@ -228,16 +228,15 @@ public class MaterialWindow extends MaterialWidget implements HasCloseHandlers<B
     public void closeWindow() {
         this.open = true;
         CloseEvent.fire(this, false);
-        Runnable callback = new Runnable() {
-            @Override
-            public void run() {
-                closeMixin.setOn(false);
-            }
-        };
         if (closeAnimation == null) {
-            callback.run();
+            closeMixin.setOn(false);
         } else {
-            closeAnimation.animate(window, callback);
+            closeAnimation.animate(window, new Runnable() {
+                @Override
+                public void run() {
+                    closeMixin.setOn(false);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fix for window crash on close when there is no animation