### PR TITLE
Added XHR Response to Complete, Sending and Success event.

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -220,15 +220,15 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
             });
 
             zdrop.on('sending', function (file) {
-                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSendingEvent(*)(file.name , file.lastModifiedDate , file.size , file.type);
+                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSendingEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
             });
 
-            zdrop.on('success', function (file, response) {
-                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSuccessEvent(*)(file.name , file.lastModifiedDate , file.size , file.type);
+            zdrop.on('success', function (file) {
+                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSuccessEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
             });
 
             zdrop.on('complete', function (file) {
-                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCompleteEvent(*)(file.name , file.lastModifiedDate , file.size , file.type);
+                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCompleteEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
             });
 
             zdrop.on('canceled', function (file) {
@@ -526,8 +526,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireSendingEvent(String fileName, String lastModified, String size, String type) {
-        SendingEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type));
+    public void fireSendingEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
+        SendingEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
     }
 
     @Override
@@ -543,8 +543,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireSuccessEvent(String fileName, String lastModified, String size, String type) {
-        SuccessEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type));
+    public void fireSuccessEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
+        SuccessEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
     }
 
     @Override
@@ -560,8 +560,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireCompleteEvent(String fileName, String lastModified, String size, String type) {
-        CompleteEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type));
+    public void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
+        CompleteEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/base/HasFileUpload.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/base/HasFileUpload.java
@@ -115,7 +115,7 @@ public interface HasFileUpload<T> extends HasHandlers {
      */
     HandlerRegistration addSendingHandler(SendingEvent.SendingHandler<T> handler);
 
-    void fireSendingEvent(String fileName, String lastModified, String size, String type);
+    void fireSendingEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage);
 
     /**
      * The file has been uploaded successfully. Gets the server response as second argument. (This event was called finished previously)
@@ -123,7 +123,7 @@ public interface HasFileUpload<T> extends HasHandlers {
      */
     HandlerRegistration addSuccessHandler(SuccessEvent.SuccessHandler<T> handler);
 
-    void fireSuccessEvent(String fileName, String lastModified, String size, String type);
+    void fireSuccessEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage);
 
     /**
      * Called when the upload was either successful or erroneous.
@@ -131,7 +131,7 @@ public interface HasFileUpload<T> extends HasHandlers {
      */
     HandlerRegistration addCompleteHandler(CompleteEvent.CompleteHandler<T> handler);
 
-    void fireCompleteEvent(String fileName, String lastModified, String size, String type);
+    void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage);
 
     /**
      * Called when a file upload gets canceled.

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/events/CompleteEvent.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/events/CompleteEvent.java
@@ -24,6 +24,7 @@ package gwt.material.design.addins.client.fileuploader.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import gwt.material.design.addins.client.fileuploader.base.HasFileUpload;
+import gwt.material.design.addins.client.fileuploader.base.UploadResponse;
 
 public class CompleteEvent<T> extends GwtEvent<CompleteEvent.CompleteHandler<T>> {
 
@@ -33,9 +34,9 @@ public class CompleteEvent<T> extends GwtEvent<CompleteEvent.CompleteHandler<T>>
         void onComplete(CompleteEvent<T> event);
     }
 
-    public static <T> void fire(HasFileUpload<T> source, T target) {
+    public static <T> void fire(HasFileUpload<T> source, T target, UploadResponse response) {
         if (TYPE != null) {
-            CompleteEvent<T> event = new CompleteEvent<T>(target);
+            CompleteEvent<T> event = new CompleteEvent<T>(target, response);
             source.fireEvent(event);
         }
     }
@@ -45,9 +46,11 @@ public class CompleteEvent<T> extends GwtEvent<CompleteEvent.CompleteHandler<T>>
     }
 
     private final T target;
+    private final UploadResponse response;
 
-    protected CompleteEvent(T target) {
+    protected CompleteEvent(T target, UploadResponse response) {
         this.target = target;
+        this.response = response;
     }
 
     @Override
@@ -57,6 +60,10 @@ public class CompleteEvent<T> extends GwtEvent<CompleteEvent.CompleteHandler<T>>
 
     public T getTarget() {
         return target;
+    }
+
+    public UploadResponse getResponse() {
+        return response;
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/events/SendingEvent.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/events/SendingEvent.java
@@ -24,6 +24,7 @@ package gwt.material.design.addins.client.fileuploader.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import gwt.material.design.addins.client.fileuploader.base.HasFileUpload;
+import gwt.material.design.addins.client.fileuploader.base.UploadResponse;
 
 public class SendingEvent<T> extends GwtEvent<SendingEvent.SendingHandler<T>> {
 
@@ -33,9 +34,9 @@ public class SendingEvent<T> extends GwtEvent<SendingEvent.SendingHandler<T>> {
         void onSending(SendingEvent<T> event);
     }
 
-    public static <T> void fire(HasFileUpload<T> source, T target) {
+    public static <T> void fire(HasFileUpload<T> source, T target, UploadResponse response) {
         if (TYPE != null) {
-            SendingEvent<T> event = new SendingEvent<T>(target);
+            SendingEvent<T> event = new SendingEvent<T>(target, response);
             source.fireEvent(event);
         }
     }
@@ -45,9 +46,11 @@ public class SendingEvent<T> extends GwtEvent<SendingEvent.SendingHandler<T>> {
     }
 
     private final T target;
+    private final UploadResponse response;
 
-    protected SendingEvent(T target) {
+    protected SendingEvent(T target, UploadResponse response) {
         this.target = target;
+        this.response = response;
     }
 
     @Override
@@ -57,6 +60,10 @@ public class SendingEvent<T> extends GwtEvent<SendingEvent.SendingHandler<T>> {
 
     public T getTarget() {
         return target;
+    }
+
+    public UploadResponse getResponse() {
+        return response;
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/events/SuccessEvent.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/events/SuccessEvent.java
@@ -24,6 +24,7 @@ package gwt.material.design.addins.client.fileuploader.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import gwt.material.design.addins.client.fileuploader.base.HasFileUpload;
+import gwt.material.design.addins.client.fileuploader.base.UploadResponse;
 
 public class SuccessEvent<T> extends GwtEvent<SuccessEvent.SuccessHandler<T>> {
 
@@ -33,9 +34,9 @@ public class SuccessEvent<T> extends GwtEvent<SuccessEvent.SuccessHandler<T>> {
         void onSuccess(SuccessEvent<T> event);
     }
 
-    public static <T> void fire(HasFileUpload<T> source, T target) {
+    public static <T> void fire(HasFileUpload<T> source, T target, UploadResponse response) {
         if (TYPE != null) {
-            SuccessEvent<T> event = new SuccessEvent<T>(target);
+            SuccessEvent<T> event = new SuccessEvent<T>(target, response);
             source.fireEvent(event);
         }
     }
@@ -45,9 +46,11 @@ public class SuccessEvent<T> extends GwtEvent<SuccessEvent.SuccessHandler<T>> {
     }
 
     private final T target;
+    private final UploadResponse response;
 
-    protected SuccessEvent(T target) {
+    protected SuccessEvent(T target, UploadResponse response) {
         this.target = target;
+        this.response = response;
     }
 
     @Override
@@ -57,6 +60,10 @@ public class SuccessEvent<T> extends GwtEvent<SuccessEvent.SuccessHandler<T>> {
 
     public T getTarget() {
         return target;
+    }
+
+    public UploadResponse getResponse() {
+        return response;
     }
 
     @Override


### PR DESCRIPTION
This is a fixed for issue https://github.com/GwtMaterialDesign/gwt-material-addins/issues/77, which we've added a feature to have ``` event.getResponse() ``` on each events ``` CompleteEvent, SuccessEvent, SendingEvent ```.