### PR TITLE
Update MaterialFileUploader.java

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -232,6 +232,9 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
             zdrop.on('complete', function (file) {
                 that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCompleteEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
             });
+            zdrop.on('complete', function (file, response) {
+                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCompleteEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText, response);
+            });
 
             zdrop.on('canceled', function (file) {
                 that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCancelEvent(*)(file.name , file.lastModifiedDate , file.size , file.type);
@@ -579,8 +582,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
-        CompleteEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
+    public void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody) {
+        CompleteEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage, responseBody));
     }
 
     @Override


### PR DESCRIPTION
This should add missing functionality of body response.
https://github.com/GwtMaterialDesign/gwt-material-addins/pull/78
https://github.com/GwtMaterialDesign/gwt-material-addins/issues/77

We have to add to class:
`gwt.material.design.addins.client.fileuploader.base.UploadResponse`

parameter `body`:
`private String body;`

and getter setter:
```
   public String getBody() {
        return body;
    }

    public void setBody(String body) {
        this.body = body;
    }
```

