### PR TITLE
fixed #92: "MaterialAutoComplete.setFocus(true) does nothing"

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
+++ b/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
@@ -33,6 +33,7 @@ import gwt.material.design.client.MaterialDesignBase;
 import gwt.material.design.client.base.*;
 import gwt.material.design.client.base.mixin.CssTypeMixin;
 import gwt.material.design.client.base.mixin.ErrorMixin;
+import gwt.material.design.client.base.mixin.FocusableMixin;
 import gwt.material.design.client.base.mixin.ProgressMixin;
 import gwt.material.design.client.constants.IconType;
 import gwt.material.design.client.constants.ProgressType;
@@ -185,6 +186,9 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
 
     private final ErrorMixin<MaterialAutoComplete, MaterialLabel> errorMixin = new ErrorMixin<>(this,
             lblError, list);
+
+    private FocusableMixin<MaterialWidget> focusableMixin;
+
     public final CssTypeMixin<AutocompleteType, MaterialAutoComplete> typeMixin = new CssTypeMixin<>(this);
 
     /**
@@ -429,6 +433,12 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
         suggestionMap.clear();
 
         clearErrorOrSuccess();
+    }
+
+    @Override
+    protected FocusableMixin<MaterialWidget> getFocusableMixin() {
+        if(focusableMixin == null) { focusableMixin = new FocusableMixin<>(new MaterialWidget(itemBox.getElement())); }
+        return focusableMixin;
     }
 
     /**


### PR DESCRIPTION
I have created/cloned a new focusableMixin field in MaterialAutoComplete. (The one in MaterialWidget is private hence I could not access it.) The original one is never accessed directly though, and I have overriden the getter, so there should be no issue.
The new focusableMixin instance is created from itemBox.getElement().
MaterialAutoComplete.setFocus() now correctly puts focus into the HtmlInputElement of the widget.
Tested in Chrome, Firefox, MSIE.