### PR TITLE
FileUploader. Support for unauthorized response and custom message body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,25 +3,25 @@
     <parent>
         <artifactId>gwt-material-parent</artifactId>
         <groupId>com.github.gwtmaterialdesign</groupId>
-        <version>1.5.1</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gwt-material-addins</artifactId>
 
     <name>Gwt Material Addins</name>
-    <version>1.5.1</version>
+    <version>1.6.0-SNAPSHOT</version>
     <description>Extra Components of GWT Material Framework</description>
 
     <properties>
-        <gwt-material.version>1.5.1</gwt-material.version>
+        <gwt-material.version>1.6.0-SNAPSHOT</gwt-material.version>
     </properties>
 
     <scm>
         <connection>scm:git:git@github.com:GwtMaterialDesign/gwt-material-addins.git</connection>
         <developerConnection>scm:git:git@github.com:GwtMaterialDesign/gwt-material-addins.git</developerConnection>
         <url>http://github.com/GwtMaterialDesign/gwt-material-addins</url>
-        <tag>v1.5.1</tag>
+        <tag>v1.6.0-SNAPSHOT</tag>
     </scm>
 
     <licenses>

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -140,6 +140,7 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
             var previewContainer = $wnd.jQuery("#" + previews).html();
             previewNode.id = "";
             var previewTemplate = previewNode.parent().html();
+            var globalResponse = "";
 
             var totalFiles = 0;
             var zdrop = new $wnd.Dropzone(e, {
@@ -206,8 +207,18 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
                 if(file.xhr !== undefined) {
                     code = file.xhr.status;
                 }
+                if(response.indexOf("401") >= 0) {
+                    response = "Unautharized. Probably Your's session expired. Log in and try again.";
+                    globalResponse = response;
+                    that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireUnauthorizedEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText, response);
+                }
                 if(response.indexOf("404") >= 0) {
                     response = "There's a problem uploading your file.";
+                    globalResponse = response;
+                }
+                if(response.indexOf("500") >= 0) {
+				    response = "There's a problem uploading your file.";
+					globalResponse = response;
                 }
                 file.previewElement.querySelector("#error-message").innerHTML = response;
                 that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireErrorEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, code, response);
@@ -225,12 +236,13 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
                 that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSendingEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
             });
 
-            zdrop.on('success', function (file) {
-                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSuccessEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
+            zdrop.on('success', function (file, response) {
+                globalResponse = response;
+                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireSuccessEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText, response);
             });
 
             zdrop.on('complete', function (file) {
-                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCompleteEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText);
+                that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireCompleteEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, file.xhr.status, file.xhr.statusText, globalResponse);
             });
 
             zdrop.on('canceled', function (file) {
@@ -511,8 +523,25 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireErrorEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
-        ErrorEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
+    public void fireErrorEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody) {
+        ErrorEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage, responseBody));
+    }
+
+    @Override
+    public HandlerRegistration addUnauthorizedHandler(final UnauthorizedEvent.UnauthorizedHandler<UploadFile> handler) {
+        return addHandler(new UnauthorizedEvent.UnauthorizedHandler<UploadFile>() {
+            @Override
+            public void onUnauthorized(UnauthorizedEvent<UploadFile> event) {
+                if (isEnabled()) {
+                    handler.onUnauthorized(event);
+                }
+            }
+        }, UnauthorizedEvent.getType());
+    }
+
+    @Override
+    public void fireUnauthorizedEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody) {
+        UnauthorizedEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage, responseBody));
     }
 
     @Override
@@ -562,8 +591,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireSuccessEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
-        SuccessEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
+    public void fireSuccessEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody) {
+        SuccessEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage, responseBody));
     }
 
     @Override
@@ -579,8 +608,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     }
 
     @Override
-    public void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage) {
-        CompleteEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage));
+    public void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody) {
+        CompleteEvent.fire(this, new UploadFile(fileName, new Date(lastModified), Double.parseDouble(size), type), new UploadResponse(responseCode, responseMessage, responseBody));
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -217,8 +217,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
                     globalResponse = response;
                 }
                 if(response.indexOf("500") >= 0) {
-				    response = "There's a problem uploading your file.";
-					globalResponse = response;
+                    response = "There's a problem uploading your file.";
+                    globalResponse = response;
                 }
                 file.previewElement.querySelector("#error-message").innerHTML = response;
                 that.@gwt.material.design.addins.client.fileuploader.MaterialFileUploader::fireErrorEvent(*)(file.name , file.lastModifiedDate , file.size , file.type, code, response);

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/base/HasFileUpload.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/base/HasFileUpload.java
@@ -98,7 +98,17 @@ public interface HasFileUpload<T> extends HasHandlers {
      */
     HandlerRegistration addErrorHandler(ErrorEvent.ErrorHandler<T> handler);
 
-    void fireErrorEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage);
+    void fireErrorEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody);
+    /**
+     * An unauthorized error occured. Probably because of session expiration.
+     * Receives the errorMessage as second parameter and if the error was due to
+     * the XMLHttpRequest the xhr object as third.
+     *
+     * @param handler
+     */
+    HandlerRegistration addUnauthorizedHandler(UnauthorizedEvent.UnauthorizedHandler<T> handler);
+
+    void fireUnauthorizedEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody);
 
     /**
      * Called with the total uploadProgress (0-100). This event can be used to show the overall upload progress of all files.
@@ -123,7 +133,7 @@ public interface HasFileUpload<T> extends HasHandlers {
      */
     HandlerRegistration addSuccessHandler(SuccessEvent.SuccessHandler<T> handler);
 
-    void fireSuccessEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage);
+    void fireSuccessEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody);
 
     /**
      * Called when the upload was either successful or erroneous.
@@ -131,7 +141,7 @@ public interface HasFileUpload<T> extends HasHandlers {
      */
     HandlerRegistration addCompleteHandler(CompleteEvent.CompleteHandler<T> handler);
 
-    void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage);
+    void fireCompleteEvent(String fileName, String lastModified, String size, String type, String responseCode, String responseMessage, String responseBody);
 
     /**
      * Called when a file upload gets canceled.

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/base/UploadResponse.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/base/UploadResponse.java
@@ -29,10 +29,17 @@ public class UploadResponse {
 
     private String code;
     private String message;
+    private String body;
 
     public UploadResponse(String code, String message) {
         this.code = code;
         this.message = message;
+    }
+
+    public UploadResponse(String code, String message, String body) {
+        this.code = code;
+        this.message = message;
+        this.body = body;
     }
 
     public String getCode() {
@@ -49,5 +56,13 @@ public class UploadResponse {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/events/UnauthorizedEvent.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/events/UnauthorizedEvent.java
@@ -1,0 +1,74 @@
+package gwt.material.design.addins.client.fileuploader.events;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.addins.client.fileuploader.base.HasFileUpload;
+import gwt.material.design.addins.client.fileuploader.base.UploadResponse;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class UnauthorizedEvent<T> extends GwtEvent<UnauthorizedEvent.UnauthorizedHandler<T>> {
+
+    private static Type<UnauthorizedHandler<?>> TYPE;
+
+    public interface UnauthorizedHandler<T> extends EventHandler {
+        void onUnauthorized(UnauthorizedEvent<T> event);
+    }
+
+    public static <T> void fire(HasFileUpload<T> source, T target, UploadResponse response) {
+        if (TYPE != null) {
+            UnauthorizedEvent<T> event = new UnauthorizedEvent<T>(target, response);
+            source.fireEvent(event);
+        }
+    }
+
+    public static Type<UnauthorizedHandler<?>> getType() {
+        return TYPE != null ? TYPE : (TYPE = new Type<UnauthorizedHandler<?>>());
+    }
+
+    private final T target;
+    private final UploadResponse response;
+
+    protected UnauthorizedEvent(T target, UploadResponse response) {
+        this.target = target;
+        this.response = response;
+    }
+
+    @Override
+    public final Type<UnauthorizedHandler<T>> getAssociatedType() {
+        return (Type) TYPE;
+    }
+
+    public T getTarget() {
+        return target;
+    }
+
+    public UploadResponse getResponse() {
+        return response;
+    }
+
+    @Override
+    protected void dispatch(UnauthorizedHandler<T> handler) {
+        handler.onUnauthorized(this);
+    }
+
+}


### PR DESCRIPTION
I've recreate from clear code previous pr:
https://github.com/GwtMaterialDesign/gwt-material-addins/pull/86
https://github.com/GwtMaterialDesign/gwt-material-addins/pull/87
https://github.com/GwtMaterialDesign/gwt-material-addins/issues/93

With this changes we now can:

- Set custom answer from server. f.e: new FileName.
- If Your's session will expire, server will return 401 and You can catch it with UnathorizedEventHandler.


Here is example of custom server answer, base on spring:
```
@RequestMapping(value = "files/upload", method = RequestMethod.POST)
public ResponseEntity<String> upload(HttpServletRequest request, HttpServletResponse response) {
    // checks is form enctype="multipart/form-data"
    if (!ServletFileUpload.isMultipartContent(request)) {
        return new ResponseEntity<String>("BAD_REQUEST", HttpStatus.BAD_REQUEST);
    } else {
        try {
            FileService.createFileFromHttpServletMultiPartRequest(request, response);
            return ResponseEntity.status(HttpStatus.CREATED).contentType(MediaType.TEXT_PLAIN).body("CUSTOM BODY RESPONSE");
        } catch (ServletException | IOException e) {
            e.printStackTrace();
            return new ResponseEntity<String>("INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
        }
    }
}
```