### PR TITLE
Add thickness property for MaterialSplitPanel

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/splitpanel/MaterialSplitPanel.java
+++ b/src/main/java/gwt/material/design/addins/client/splitpanel/MaterialSplitPanel.java
@@ -23,6 +23,7 @@ package gwt.material.design.addins.client.splitpanel;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+
 import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.splitpanel.constants.Dock;
 import gwt.material.design.client.MaterialDesignBase;
@@ -79,6 +80,7 @@ public class MaterialSplitPanel extends MaterialWidget {
     private double bottomMin;
     private double bottomMax;
     private double barPosition = 50;
+    private String thickness = "8px";
     private Dock dock = Dock.LEFT;
     private Axis axis = Axis.HORIZONTAL;
 
@@ -89,13 +91,14 @@ public class MaterialSplitPanel extends MaterialWidget {
     @Override
     protected void onLoad() {
         super.onLoad();
-        initSplitter(getElement(), getBarPosition(), getRightMax(), getRightMin(), getLeftMax(), getLeftMin(), getTopMax(), getTopMin(), getBottomMax(), getBottomMin(), getDock().getCssName(), getAxis().getCssName());
+        initSplitter(getElement(), getBarPosition(), getThickness(), getRightMax(), getRightMin(), getLeftMax(), getLeftMin(), getTopMax(), getTopMin(), getBottomMax(), getBottomMin(), getDock().getCssName(), getAxis().getCssName());
     }
 
     /**
      * Initialize the splitter component
      * @param e - The element you need to split
      * @param barPosition - The position of the bar based on percentage by default it's 50%
+     * @param thickness - The thickness of the splitter bar
      * @param rightMax - The maximum right space while dragging the splitter bar horizontally
      * @param rightMin - The minimum right space while dragging the splitter bar horizontally
      * @param leftMax - The maximum left space while dragging the splitter bar horizontally
@@ -107,11 +110,11 @@ public class MaterialSplitPanel extends MaterialWidget {
      * @param dock - When clicking on the white line located in the middle of splitter bar, depends on docking position it will collapse to that direction
      * @param orientation - There are two types of orientation : HORIZONTAL (Default) and VERTICAL
      */
-    private native void initSplitter(Element e,double barPosition, double rightMax, double rightMin, double leftMax, double leftMin, double topMax, double topMin, double bottomMin, double bottomMax, String dock, String orientation) /*-{
+    private native void initSplitter(Element e,double barPosition, String thickness, double rightMax, double rightMin, double leftMax, double leftMin, double topMax, double topMin, double bottomMin, double bottomMax, String dock, String orientation) /*-{
         $wnd.jQuery(document).ready(function() {
             var splitted = $wnd.jQuery(e);
             if( splitted[0].touchSplitter == null ) {
-                splitted.touchSplit({barPosition: barPosition, thickness: "8px", rightMax: rightMax, rightMin: rightMin, leftMax: leftMax, leftMin: leftMin, topMax: topMax, topMin: topMin, bottomMax: bottomMax, bottomMin: bottomMin, dock: dock, orientation: orientation});
+                splitted.touchSplit({barPosition: barPosition, thickness: thickness, rightMax: rightMax, rightMin: rightMin, leftMax: leftMax, leftMin: leftMin, topMax: topMax, topMin: topMin, bottomMax: bottomMax, bottomMin: bottomMin, dock: dock, orientation: orientation});
             }
         });
     }-*/;
@@ -283,12 +286,28 @@ public class MaterialSplitPanel extends MaterialWidget {
     public double getBarPosition() {
         return barPosition / 100;
     }
-
+    
     /**
      * Set the bar position in percent
      * @param barPosition
      */
     public void setBarPosition(double barPosition) {
         this.barPosition = barPosition;
+    }    
+
+    /**
+     * Get the bar thickness
+     * @return
+     */
+    public String getThickness() {
+        return thickness;
     }
+
+    /**
+     * Set the bar thickness
+     * @param thickness
+     */
+    public void setThickness(String thickness) {
+        this.thickness = thickness;
+    }    
 }


### PR DESCRIPTION
The default thickness of 8px is too narrow on a device to easily touch-drag. Exposing the thickness as a property enables customizing it to something that works better, e.g. 10px. 