### PR TITLE
Fixed gwt-material version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Extra Components of GWT Material Framework</description>
 
     <properties>
-        <gwt-material.version>1.6.0-SNAPSHOT</gwt-material.version>
+        <gwt-material.version>1.6.0</gwt-material.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
It was pointing to non-existent version.