### PR TITLE
Use https for doc viewer url

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/docviewer/MaterialDocViewer.java
+++ b/src/main/java/gwt/material/design/addins/client/docviewer/MaterialDocViewer.java
@@ -64,7 +64,7 @@ public class MaterialDocViewer extends MaterialWidget {
     @Override
     protected void onLoad() {
         super.onLoad();
-        getElement().setAttribute("src", "http://docs.google.com/gview?url=" + url + "&embedded=" + embedded);
+        getElement().setAttribute("src", "https://docs.google.com/gview?url=" + url + "&embedded=" + embedded);
     }
 
     /**


### PR DESCRIPTION
Use https as default. Otherwise it is not possible to use MaterialDocViewer on a https website.
See https://gwtmaterialdesign.github.io/gwt-material-demo-errai/#docviewer

The content is blocked by the browser because of mixed content.