### PR TITLE
Fixes #189, clear should not remove label, error label and listbox

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
+++ b/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
@@ -217,7 +217,7 @@ public class MaterialComboBox<T> extends AbstractValueWidget<T> implements HasPl
         final Iterator<Widget> it = iterator();
         while (it.hasNext()) {
         	final Widget widget = it.next();
-        	if (widget != label && widget != lblError) {
+        	if (widget != label && widget != lblError && widget != listbox) {
 	            it.remove();
         	}
         }

--- a/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
+++ b/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
@@ -46,6 +46,7 @@ import gwt.material.design.client.ui.html.Option;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import static gwt.material.design.addins.client.combobox.js.JsComboBox.$;
@@ -209,6 +210,17 @@ public class MaterialComboBox<T> extends AbstractValueWidget<T> implements HasPl
             values.add((T) ((Option) child).getValue());
         }
         listbox.add(child);
+    }
+
+    @Override
+    public void clear() {
+        final Iterator<Widget> it = iterator();
+        while (it.hasNext()) {
+        	final Widget widget = it.next();
+        	if (widget != label && widget != lblError) {
+	            it.remove();
+        	}
+        }
     }
 
     /**


### PR DESCRIPTION
overrides clear() so that label,  error label and most importantly listbox are not removed, for example when calling setAcceptableValues() after the combobox has been loaded and initialized. 
Symptoms: missing label after values are loaded, missing error label, getValue() always returns false (because the listbox is gone).

Note that this bug only manifests itself when the combobox values are loaded as the result of an async call (for example GWT service call), so that it comes after initialize(). If the values are loaded when it is constructed, before initialize(), you will not see this bug