### PR TITLE
Added the dropdownParent property to MaterialComboBox

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
+++ b/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
@@ -43,6 +43,7 @@ import gwt.material.design.client.ui.MaterialLabel;
 import gwt.material.design.client.ui.html.Label;
 import gwt.material.design.client.ui.html.OptGroup;
 import gwt.material.design.client.ui.html.Option;
+import gwt.material.design.jquery.client.api.JQueryElement;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -98,6 +99,7 @@ public class MaterialComboBox<T> extends AbstractValueWidget<T> implements HasPl
     private boolean hideSearch;
     private int limit;
     private boolean closeOnSelect = true;
+    private String dropdownParent = "body";
 
     private int selectedIndex;
     private String uid = DOM.createUniqueId();
@@ -146,6 +148,8 @@ public class MaterialComboBox<T> extends AbstractValueWidget<T> implements HasPl
         options.placeholder = placeholder;
         options.maximumSelectionLength = limit;
         options.closeOnSelect = closeOnSelect;
+        options.dropdownParent = $(dropdownParent);
+        
         if (isHideSearch()) {
             options.minimumResultsForSearch = "Infinity";
         }
@@ -212,6 +216,18 @@ public class MaterialComboBox<T> extends AbstractValueWidget<T> implements HasPl
         listbox.add(child);
     }
 
+    /**
+     * Sets the parent element of the dropdown
+     * @param dropdownParent
+     */
+    public void setDropdownParent(String dropdownParent) {
+		this.dropdownParent = dropdownParent;
+	}
+    
+    public String getDropdownParent() {
+		return dropdownParent;
+	}
+    
     /**
      * Sets multi-value select boxes.
      */

--- a/src/main/java/gwt/material/design/addins/client/combobox/js/JsComboBoxOptions.java
+++ b/src/main/java/gwt/material/design/addins/client/combobox/js/JsComboBoxOptions.java
@@ -19,6 +19,7 @@
  */
 package gwt.material.design.addins.client.combobox.js;
 
+import gwt.material.design.jquery.client.api.JQueryElement;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
@@ -33,6 +34,9 @@ public class JsComboBoxOptions {
 
     @JsProperty
     public String placeholder;
+    
+    @JsProperty
+    public JQueryElement dropdownParent;
 
     @JsProperty
     public boolean allowClear;


### PR DESCRIPTION
By default the dropdownParent is the body element. With this property you can specify the parent setting this property as string JQuery selector.