### PR TITLE
API Rework (2.0)

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
+++ b/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
@@ -169,7 +169,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
     }
 
     private Map<Suggestion, Widget> suggestionMap = new LinkedHashMap<>();
-    private Label lblPlaceholder = new Label();
+    private Label placeholderLabel = new Label();
 
     private List<ListItem> itemsHighlighted = new ArrayList<>();
     private FlowPanel panel = new FlowPanel();
@@ -178,14 +178,14 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
     private TextBox itemBox = new TextBox();
     private SuggestBox box;
     private int limit = 0;
-    private MaterialLabel lblError = new MaterialLabel();
+    private MaterialLabel errorLabel = new MaterialLabel();
     private final ProgressMixin<MaterialAutoComplete> progressMixin = new ProgressMixin<>(this);
 
     private String selectedChipStyle = "blue white-text";
     private boolean directInputAllowed = true;
     private MaterialChipProvider chipProvider = new DefaultMaterialChipProvider();
 
-    private final ErrorMixin<AbstractValueWidget, MaterialLabel> errorMixin = new ErrorMixin<>(this, lblError, list, lblPlaceholder);
+    private final ErrorMixin<AbstractValueWidget, MaterialLabel> errorMixin = new ErrorMixin<>(this, errorLabel, list, placeholderLabel);
 
     private FocusableMixin<MaterialWidget> focusableMixin;
     private ReadOnlyMixin<MaterialAutoComplete, TextBox> readOnlyMixin;
@@ -237,14 +237,14 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
         itemBox.getElement().setId(autocompleteId);
 
         item.add(box);
-        item.add(lblPlaceholder);
+        item.add(placeholderLabel);
         list.add(item);
 
         list.addDomHandler(event -> box.showSuggestionList(), ClickEvent.getType());
 
         itemBox.addBlurHandler(blurEvent -> {
             if (getValue().size() > 0) {
-                lblPlaceholder.addStyleName(CssName.ACTIVE);
+                placeholderLabel.addStyleName(CssName.ACTIVE);
             }
         });
 
@@ -315,7 +315,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
         panel.add(list);
         panel.getElement().setAttribute("onclick",
             "document.getElementById('" + autocompleteId + "').focus()");
-        panel.add(lblError);
+        panel.add(errorLabel);
         box.setFocus(true);
     }
 
@@ -396,7 +396,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
      */
     public void clear() {
         itemBox.setValue("");
-        lblPlaceholder.removeStyleName(CssName.ACTIVE);
+        placeholderLabel.removeStyleName(CssName.ACTIVE);
 
         Collection<Widget> values = suggestionMap.values();
         for (Widget widget : values) {
@@ -456,7 +456,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
         }
         setValue(list, fireEvents);
         if (itemValues.size() > 0) {
-            lblPlaceholder.addStyleName(CssName.ACTIVE);
+            placeholderLabel.addStyleName(CssName.ACTIVE);
         }
     }
 
@@ -510,12 +510,12 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
 
     @Override
     public String getPlaceholder() {
-        return lblPlaceholder.getText();
+        return placeholderLabel.getText();
     }
 
     @Override
     public void setPlaceholder(String placeholder) {
-        lblPlaceholder.setText(placeholder);
+        placeholderLabel.setText(placeholder);
     }
 
     /**
@@ -781,7 +781,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
     public void setValue(List<? extends Suggestion> value, boolean fireEvents) {
         clear();
         if (value != null) {
-            lblPlaceholder.addStyleName(CssName.ACTIVE);
+            placeholderLabel.addStyleName(CssName.ACTIVE);
             for (Suggestion suggestion : value) {
                 addItem(suggestion);
             }
@@ -798,5 +798,17 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
     @Override
     public ErrorMixin<AbstractValueWidget, MaterialLabel> getErrorMixin() {
         return errorMixin;
+    }
+
+    public Label getPlaceholderLabel() {
+        return placeholderLabel;
+    }
+
+    public TextBox getItemBox() {
+        return itemBox;
+    }
+
+    public MaterialLabel getErrorLabel() {
+        return errorLabel;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
+++ b/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
@@ -219,13 +219,13 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
      */
     public MaterialAutoComplete(SuggestOracle suggestions) {
         this();
-        generateAutoComplete(suggestions);
+        build(suggestions);
     }
 
     /**
      * Generate and build the List Items to be set on Auto Complete box.
      */
-    protected void generateAutoComplete(SuggestOracle suggestions) {
+    protected void build(SuggestOracle suggestions) {
         list.setStyleName(AddinsCssName.MULTIVALUESUGGESTBOX_LIST);
         this.suggestions = suggestions;
         final ListItem item = new ListItem();
@@ -489,7 +489,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
      */
     public void setSuggestions(SuggestOracle suggestions) {
         this.suggestions = suggestions;
-        generateAutoComplete(suggestions);
+        build(suggestions);
     }
 
     public void setSuggestions(SuggestOracle suggestions, AutocompleteType type) {

--- a/src/main/java/gwt/material/design/addins/client/bubble/MaterialBubble.java
+++ b/src/main/java/gwt/material/design/addins/client/bubble/MaterialBubble.java
@@ -125,4 +125,8 @@ public class MaterialBubble extends MaterialWidget implements HasPosition {
         positionMixin.setCssName(position);
         initBubble();
     }
+
+    public MaterialWidget getTriangle() {
+        return triangle;
+    }
 }

--- a/src/main/java/gwt/material/design/addins/client/bubble/MaterialBubble.java
+++ b/src/main/java/gwt/material/design/addins/client/bubble/MaterialBubble.java
@@ -62,7 +62,7 @@ import static gwt.material.design.addins.client.bubble.js.JsBubble.$;
 public class MaterialBubble extends MaterialWidget implements HasPosition {
 
     private MaterialWidget triangle = new MaterialWidget(Document.get().createDivElement());
-    private final CssNameMixin<MaterialWidget, Position> positionMixin;
+    private CssNameMixin<MaterialWidget, Position> positionMixin;
 
     static {
         if (MaterialAddins.isDebug()) {
@@ -76,11 +76,7 @@ public class MaterialBubble extends MaterialWidget implements HasPosition {
 
     public MaterialBubble() {
         super(Document.get().createSpanElement(), AddinsCssName.BUBBLE);
-        triangle.setStyleName(AddinsCssName.TRIANGLE);
-        positionMixin = new CssNameMixin<>(triangle);
-        positionMixin.setCssName(Position.LEFT);
-        add(triangle);
-        setShadow(1);
+        build();
     }
 
     public MaterialBubble(Color textColor, Color backgroundColor) {
@@ -92,6 +88,15 @@ public class MaterialBubble extends MaterialWidget implements HasPosition {
     public MaterialBubble(Color textColor, Color backgroundColor, Position position) {
         this(textColor, backgroundColor);
         setPosition(position);
+    }
+
+    @Override
+    protected void build() {
+        triangle.setStyleName(AddinsCssName.TRIANGLE);
+        positionMixin = new CssNameMixin<>(triangle);
+        positionMixin.setCssName(Position.LEFT);
+        add(triangle);
+        setShadow(1);
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
+++ b/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
@@ -40,11 +40,9 @@ import gwt.material.design.client.base.mixin.ErrorMixin;
 import gwt.material.design.client.base.mixin.ReadOnlyMixin;
 import gwt.material.design.client.constants.CssName;
 import gwt.material.design.client.ui.MaterialLabel;
-import gwt.material.design.client.ui.MaterialToast;
 import gwt.material.design.client.ui.html.Label;
 import gwt.material.design.client.ui.html.OptGroup;
 import gwt.material.design.client.ui.html.Option;
-import gwt.material.design.jquery.client.api.JQuery;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -110,12 +108,12 @@ public class MaterialComboBox<T> extends AbstractValueWidget<List<T>> implements
     protected List<T> values = new ArrayList<>();
 
     private Label label = new Label();
-    private MaterialLabel lblError = new MaterialLabel();
+    private MaterialLabel errorLabel = new MaterialLabel();
     protected MaterialWidget listbox = new MaterialWidget(Document.get().createSelectElement());
     private HandlerRegistration valueChangeHandler, clearInputHandler;
 
     private final ErrorMixin<AbstractValueWidget, MaterialLabel> errorMixin = new ErrorMixin<>(
-            this, lblError, this.asWidget());
+            this, errorLabel, this.asWidget());
     private ReadOnlyMixin<MaterialComboBox, MaterialWidget> readOnlyMixin;
 
     // By default the key is generated using toString
@@ -138,9 +136,9 @@ public class MaterialComboBox<T> extends AbstractValueWidget<List<T>> implements
             label.setInitialClasses(AddinsCssName.SELECT2LABEL);
             super.add(listbox);
             super.add(label);
-            lblError.setLayoutPosition(Style.Position.ABSOLUTE);
-            lblError.setMarginTop(15);
-            super.add(lblError);
+            errorLabel.setLayoutPosition(Style.Position.ABSOLUTE);
+            errorLabel.setMarginTop(15);
+            super.add(errorLabel);
             setId(uid);
 
             listbox.setGwtDisplay(Style.Display.BLOCK);
@@ -576,7 +574,7 @@ public class MaterialComboBox<T> extends AbstractValueWidget<List<T>> implements
         final Iterator<Widget> it = iterator();
         while (it.hasNext()) {
             final Widget widget = it.next();
-            if (widget != label && widget != lblError && widget != listbox) {
+            if (widget != label && widget != errorLabel && widget != listbox) {
                 it.remove();
             }
         }
@@ -667,5 +665,9 @@ public class MaterialComboBox<T> extends AbstractValueWidget<List<T>> implements
 
     public Label getLabel() {
         return label;
+    }
+
+    public MaterialLabel getErrorLabel() {
+        return errorLabel;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
+++ b/src/main/java/gwt/material/design/addins/client/combobox/MaterialComboBox.java
@@ -129,6 +129,11 @@ public class MaterialComboBox<T> extends AbstractValueWidget<List<T>> implements
     protected void onLoad() {
         super.onLoad();
 
+        build();
+    }
+
+    @Override
+    protected void build() {
         if (!initialized) {
             label.setInitialClasses(AddinsCssName.SELECT2LABEL);
             super.add(listbox);

--- a/src/main/java/gwt/material/design/addins/client/cutout/MaterialCutOut.java
+++ b/src/main/java/gwt/material/design/addins/client/cutout/MaterialCutOut.java
@@ -110,6 +110,19 @@ public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<M
 
     public MaterialCutOut() {
         super(Document.get().createDivElement(), AddinsCssName.MATERIAL_CUTOUT);
+
+        build();
+    }
+
+    public MaterialCutOut(Color backgroundColor, Boolean circle, Double opacity) {
+        this();
+        setBackgroundColor(backgroundColor);
+        setCircle(circle);
+        setOpacity(opacity);
+    }
+
+    @Override
+    protected void build() {
         focusElement = Document.get().createDivElement();
         getElement().appendChild(focusElement);
 
@@ -128,13 +141,6 @@ public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<M
         style.setProperty("content", "\'\'");
         style.setPosition(Position.ABSOLUTE);
         style.setZIndex(-1);
-    }
-
-    public MaterialCutOut(Color backgroundColor, Boolean circle, Double opacity) {
-        this();
-        setBackgroundColor(backgroundColor);
-        setCircle(circle);
-        setOpacity(opacity);
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/cutout/MaterialCutOut.java
+++ b/src/main/java/gwt/material/design/addins/client/cutout/MaterialCutOut.java
@@ -34,6 +34,7 @@ import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.client.base.HasCircle;
+import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.base.helper.ColorHelper;
 import gwt.material.design.client.constants.Color;
@@ -86,13 +87,12 @@ import static gwt.material.design.jquery.client.api.JQuery.$;
  */
 // @formatter:on
 public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<MaterialCutOut>,
-        HasOpenHandlers<MaterialCutOut>, HasCircle {
+        HasOpenHandlers<MaterialCutOut>, HasCircle, HasDurationTransition {
 
     private Color backgroundColor = Color.BLUE;
     private double opacity = 0.8;
 
     private boolean animated = true;
-    private String animationDuration = "0.5s";
     private String animationTimingFunction = "ease";
     private String backgroundSize;
 
@@ -106,6 +106,7 @@ public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<M
 
     private HandlerRegistration resizeHandler;
     private HandlerRegistration scrollHandler;
+    private int duration = 500;
 
     public MaterialCutOut() {
         super(Document.get().createDivElement(), AddinsCssName.MATERIAL_CUTOUT);
@@ -158,23 +159,6 @@ public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<M
     @Override
     public double getOpacity() {
         return opacity;
-    }
-
-    /**
-     * @return the animation duration of the opening cut out
-     */
-    public String getAnimationDuration() {
-        return animationDuration;
-    }
-
-    /**
-     * Sets the animation duration of the opening cut out.
-     * The default is 0.5s.
-     *
-     * @param animationDuration The duration in CSS time unit, such as s and ms.
-     */
-    public void setAnimationDuration(String animationDuration) {
-        this.animationDuration = animationDuration;
     }
 
     /**
@@ -439,8 +423,8 @@ public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<M
 
     protected void setupTransition() {
         if (animated) {
-            focusElement.getStyle().setProperty("WebkitTransition", "box-shadow " + animationDuration + " " + animationTimingFunction);
-            focusElement.getStyle().setProperty("transition", "box-shadow " + animationDuration + " " + animationTimingFunction);
+            focusElement.getStyle().setProperty("WebkitTransition", "box-shadow " + getDuration() + "ms " + animationTimingFunction);
+            focusElement.getStyle().setProperty("transition", "box-shadow " + getDuration() + "ms " + animationTimingFunction);
         } else {
             focusElement.getStyle().clearProperty("WebkitTransition");
             focusElement.getStyle().clearProperty("transition");
@@ -490,5 +474,15 @@ public class MaterialCutOut extends MaterialWidget implements HasCloseHandlers<M
 
     public Element getFocusElement() {
         return focusElement;
+    }
+
+    @Override
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -93,9 +93,8 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
 
     public MaterialFileUploader() {
         super(Document.get().createDivElement(), AddinsCssName.FILEUPLOADER);
-        setId(AddinsCssName.ZDROP);
-        add(uploadPreview);
-        options = getDefaultOptions();
+
+        build();
     }
 
     public MaterialFileUploader(String url, FileMethod method) {
@@ -120,6 +119,13 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
         options.withCredentials = false;
         options.acceptedFiles = "";
         return options;
+    }
+
+    @Override
+    protected void build() {
+        setId(AddinsCssName.ZDROP);
+        add(uploadPreview);
+        options = getDefaultOptions();
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadCollection.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadCollection.java
@@ -43,6 +43,11 @@ public class MaterialUploadCollection extends MaterialCollection {
     private MaterialProgress progress = new MaterialProgress();
 
     public MaterialUploadCollection() {
+        build();
+    }
+
+    @Override
+    protected void build() {
         // Element property
         setStyleName(AddinsCssName.PREVIEWS);
         addStyleName(CssName.CARD);
@@ -98,5 +103,45 @@ public class MaterialUploadCollection extends MaterialCollection {
 
     public MaterialCollectionItem getItem() {
         return item;
+    }
+
+    public MaterialWidget getDropInfo() {
+        return dropInfo;
+    }
+
+    public MaterialWidget getNameWrapper() {
+        return nameWrapper;
+    }
+
+    public MaterialWidget getErrorWrapper() {
+        return errorWrapper;
+    }
+
+    public Span getName() {
+        return name;
+    }
+
+    public Span getSize() {
+        return size;
+    }
+
+    public Span getErrorMessage() {
+        return errorMessage;
+    }
+
+    public MaterialCollectionSecondary getSecondaryAction() {
+        return secondaryAction;
+    }
+
+    public MaterialButton getBtnClear() {
+        return btnClear;
+    }
+
+    public MaterialIcon getPreviewIcon() {
+        return previewIcon;
+    }
+
+    public MaterialProgress getProgress() {
+        return progress;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadHeader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadHeader.java
@@ -44,6 +44,12 @@ public class MaterialUploadHeader extends MaterialWidget {
 
     public MaterialUploadHeader() {
         super(Document.get().createDivElement(), AddinsCssName.HEADER);
+
+        build();
+    }
+
+    @Override
+    protected void build() {
         iconClose.setId(AddinsCssName.UPLOAD_CLOSE);
         iconClose.setCircle(true);
         iconClose.setWaves(WavesType.DEFAULT);

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadLabel.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadLabel.java
@@ -34,6 +34,12 @@ public class MaterialUploadLabel extends MaterialWidget implements HasTitle {
 
     public MaterialUploadLabel() {
         super(Document.get().createDivElement(), AddinsCssName.UPLOAD_LABEL);
+
+        build();
+    }
+
+    @Override
+    protected void build() {
         add(icon);
     }
 

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadPreview.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialUploadPreview.java
@@ -30,6 +30,12 @@ public class MaterialUploadPreview extends MaterialWidget {
 
     public MaterialUploadPreview() {
         super(Document.get().createDivElement(), AddinsCssName.PREVIEW_CONTAINER);
+
+        build();
+    }
+
+    @Override
+    protected void build() {
         uploadHeader.setPreview(this);
         add(uploadHeader);
         add(uploadCollection);

--- a/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
+++ b/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
@@ -26,6 +26,7 @@ import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.client.MaterialDesignBase;
 import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.client.base.MaterialWidget;
+import gwt.material.design.client.base.TransitionProperty;
 import gwt.material.design.client.base.mixin.CssNameMixin;
 import gwt.material.design.client.constants.IconSize;
 import gwt.material.design.client.ui.MaterialIcon;
@@ -92,7 +93,7 @@ public class MaterialIconMorph extends MaterialWidget implements HasDurationTran
 
     @Override
     public void setDuration(int duration) {
-        setTransition("all", duration);
+        setTransition(new TransitionProperty(duration, "all"));
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
+++ b/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
@@ -78,6 +78,11 @@ public class MaterialIconMorph extends MaterialWidget implements HasDurationTran
     protected void onLoad() {
         super.onLoad();
 
+        build();
+    }
+
+    @Override
+    protected void build() {
         if (getWidgetCount() >= 2) {
             source = (MaterialIcon) getWidget(0);
             source.addStyleName(AddinsCssName.ICONS + " " + AddinsCssName.SOURCE);

--- a/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
+++ b/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
@@ -54,6 +54,7 @@ import gwt.material.design.client.ui.MaterialIcon;
  *
  * @author kevzlou7979
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/snapshot/#morphingIcons">Material Icon Morph</a>
+ * @see <a href="https://material.io/guidelines/motion/creative-customization.html#creative-customization-icons">Material Design Specification</a>
  */
 //@formatter:on
 public class MaterialIconMorph extends MaterialWidget implements HasDurationTransition {

--- a/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
+++ b/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
@@ -20,9 +20,11 @@
 package gwt.material.design.addins.client.iconmorph;
 
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.client.MaterialDesignBase;
+import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.base.mixin.CssNameMixin;
 import gwt.material.design.client.constants.IconSize;
@@ -54,7 +56,7 @@ import gwt.material.design.client.ui.MaterialIcon;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/snapshot/#morphingIcons">Material Icon Morph</a>
  */
 //@formatter:on
-public class MaterialIconMorph extends MaterialWidget {
+public class MaterialIconMorph extends MaterialWidget implements HasDurationTransition {
 
     static {
         if (MaterialAddins.isDebug()) {
@@ -65,6 +67,7 @@ public class MaterialIconMorph extends MaterialWidget {
     }
 
     private final CssNameMixin<MaterialIconMorph, IconSize> sizeMixin = new CssNameMixin<>(this);
+    private MaterialIcon source, target;
 
     public MaterialIconMorph() {
         super(Document.get().createDivElement(), AddinsCssName.ANIM_CONTAINER);
@@ -76,14 +79,32 @@ public class MaterialIconMorph extends MaterialWidget {
         super.onLoad();
 
         if (getWidgetCount() >= 2) {
-            MaterialIcon source = (MaterialIcon) getWidget(0);
+            source = (MaterialIcon) getWidget(0);
             source.addStyleName(AddinsCssName.ICONS + " " + AddinsCssName.SOURCE);
-            MaterialIcon target = (MaterialIcon) getWidget(1);
+            target = (MaterialIcon) getWidget(1);
             target.addStyleName(AddinsCssName.ICONS + " " + AddinsCssName.TARGET);
         }
     }
 
     public void setIconSize(IconSize size) {
         sizeMixin.setCssName(size);
+    }
+
+    @Override
+    public void setDuration(int duration) {
+        setTransition("all", duration);
+    }
+
+    @Override
+    public int getDuration() {
+        return 0;
+    }
+
+    public MaterialIcon getSource() {
+        return source;
+    }
+
+    public MaterialIcon getTarget() {
+        return target;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
+++ b/src/main/java/gwt/material/design/addins/client/iconmorph/MaterialIconMorph.java
@@ -20,13 +20,12 @@
 package gwt.material.design.addins.client.iconmorph;
 
 import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
 import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.client.MaterialDesignBase;
 import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.client.base.MaterialWidget;
-import gwt.material.design.client.base.TransitionProperty;
+import gwt.material.design.client.base.TransitionConfig;
 import gwt.material.design.client.base.mixin.CssNameMixin;
 import gwt.material.design.client.constants.IconSize;
 import gwt.material.design.client.ui.MaterialIcon;
@@ -93,7 +92,7 @@ public class MaterialIconMorph extends MaterialWidget implements HasDurationTran
 
     @Override
     public void setDuration(int duration) {
-        setTransition(new TransitionProperty(duration, "all"));
+        setTransition(new TransitionConfig(duration, "all"));
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/masonry/MaterialMasonry.java
+++ b/src/main/java/gwt/material/design/addins/client/masonry/MaterialMasonry.java
@@ -27,6 +27,7 @@ import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.addins.client.masonry.js.JsMasonryOptions;
 import gwt.material.design.client.MaterialDesignBase;
+import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.constants.CssName;
 import gwt.material.design.client.ui.MaterialRow;
@@ -62,7 +63,7 @@ import static gwt.material.design.addins.client.masonry.js.JsMasonry.$;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#masonry">Material Masonry</a>
  */
 //@formatter:on
-public class MaterialMasonry extends MaterialRow {
+public class MaterialMasonry extends MaterialRow implements HasDurationTransition {
 
     static {
         if (MaterialAddins.isDebug()) {
@@ -78,7 +79,7 @@ public class MaterialMasonry extends MaterialRow {
     private boolean percentPosition = true;
     private boolean originLeft = true;
     private boolean originTop = true;
-    private double transitionDuration = 400;
+    private int duration = 400;
     private boolean initialize;
 
     private MaterialWidget sizerDiv = new MaterialWidget(Document.get().createDivElement());
@@ -116,7 +117,7 @@ public class MaterialMasonry extends MaterialRow {
         options.columnWidth = "." + AddinsCssName.COL_SIZER;
         options.originLeft = isOriginLeft();
         options.originTop = isOriginTop();
-        options.transitionDuration = getTransitionDuration() + "ms";
+        options.transitionDuration = getDuration() + "ms";
         return options;
     }
 
@@ -266,21 +267,17 @@ public class MaterialMasonry extends MaterialRow {
         this.originTop = originTop;
     }
 
-    /**
-     * Get the transition duration in milliseconds.
-     */
-    public double getTransitionDuration() {
-        return transitionDuration;
-    }
-
-    /**
-     * Sets the transition duration in milliseconds, if 0 then there will be no transition.
-     */
-    public void setTransitionDuration(double transitionDuration) {
-        this.transitionDuration = transitionDuration;
-    }
-
     public MaterialWidget getSizerDiv() {
         return sizerDiv;
+    }
+
+    @Override
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/masonry/MaterialMasonry.java
+++ b/src/main/java/gwt/material/design/addins/client/masonry/MaterialMasonry.java
@@ -86,10 +86,8 @@ public class MaterialMasonry extends MaterialRow implements HasDurationTransitio
 
     public MaterialMasonry() {
         super(Document.get().createDivElement(), AddinsCssName.MASONRY, CssName.ROW);
-        enableFeature(Feature.ONLOAD_ADD_QUEUE, true);
-        sizerDiv.setWidth("8.3333%");
-        sizerDiv.setStyleName(AddinsCssName.COL_SIZER);
-        add(sizerDiv);
+
+        build();
     }
 
     @Override
@@ -100,6 +98,14 @@ public class MaterialMasonry extends MaterialRow implements HasDurationTransitio
         if (!initialize) {
             initialize = true;
         }
+    }
+
+    @Override
+    protected void build() {
+        enableFeature(Feature.ONLOAD_ADD_QUEUE, true);
+        sizerDiv.setWidth("8.3333%");
+        sizerDiv.setStyleName(AddinsCssName.COL_SIZER);
+        add(sizerDiv);
     }
 
     public void initMasonry() {

--- a/src/main/java/gwt/material/design/addins/client/menubar/MaterialMenuBar.java
+++ b/src/main/java/gwt/material/design/addins/client/menubar/MaterialMenuBar.java
@@ -83,6 +83,12 @@ public class MaterialMenuBar extends MaterialWidget {
     @Override
     protected void onLoad() {
         super.onLoad();
+
+        build();
+    }
+
+    @Override
+    protected void build() {
         $(getElement()).find(".dropdown-content li").css("minHeight", minHeight);
         $(getElement()).find(".dropdown-content li").css("lineHeight", minHeight);
         $(getElement()).find(".dropdown-content li").css("maxHeight", minHeight);

--- a/src/main/java/gwt/material/design/addins/client/menubar/MaterialMenuBar.java
+++ b/src/main/java/gwt/material/design/addins/client/menubar/MaterialMenuBar.java
@@ -62,6 +62,7 @@ import static gwt.material.design.jquery.client.api.JQuery.$;
  *
  * @author kevzlou7979
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#menubar">MenuBar</a>
+ * @see <a href="https://material.io/guidelines/components/menus.html">Material Design Specification</a>
  */
 //@formatter:on
 public class MaterialMenuBar extends MaterialWidget {

--- a/src/main/java/gwt/material/design/addins/client/overlay/MaterialOverlay.java
+++ b/src/main/java/gwt/material/design/addins/client/overlay/MaterialOverlay.java
@@ -28,6 +28,7 @@ import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.addins.client.pathanimator.MaterialPathAnimator;
 import gwt.material.design.client.MaterialDesignBase;
+import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.constants.Color;
 import gwt.material.design.client.constants.IconType;
@@ -60,7 +61,7 @@ import static gwt.material.design.jquery.client.api.JQuery.$;
  * @author kevzlou7979
  */
 //@formatter:on
-public class MaterialOverlay extends MaterialWidget implements HasOpenHandlers<MaterialOverlay>, HasCloseHandlers<MaterialOverlay> {
+public class MaterialOverlay extends MaterialWidget implements HasOpenHandlers<MaterialOverlay>, HasCloseHandlers<MaterialOverlay>, HasDurationTransition {
 
     static {
         if (MaterialAddins.isDebug()) {
@@ -157,36 +158,35 @@ public class MaterialOverlay extends MaterialWidget implements HasOpenHandlers<M
         this.source = source;
     }
 
-    public double getDuration() {
+    @Override
+    public int getDuration() {
         return animator.getDuration();
     }
 
-    /**
-     * Duration (in seconds) of animation. Default is 0.3 seconds.
-     */
-    public void setDuration(double duration) {
+    @Override
+    public void setDuration(int duration) {
         animator.setDuration(duration);
     }
 
-    public double getTargetShowDuration() {
+    public int getTargetShowDuration() {
         return animator.getTargetShowDuration();
     }
 
     /**
-     * Duration (in seconds) of targetElement to become visible, if hidden initially. The library will automatically try to figure this out from the element's computed styles. Default is 0 seconds.
+     * Duration (in milliseconds) of targetElement to become visible, if hidden initially. The library will automatically try to figure this out from the element's computed styles. Default is 0 seconds.
      */
-    public void setTargetShowDuration(double targetShowDuration) {
+    public void setTargetShowDuration(int targetShowDuration) {
         animator.setTargetShowDuration(targetShowDuration);
     }
 
-    public double getExtraTransitionDuration() {
+    public int getExtraTransitionDuration() {
         return animator.getExtraTransitionDuration();
     }
 
     /**
-     * Extra duration (in seconds) of targetElement to provide visual continuity between the animation and the rendering of the targetElement. Default is 1 second
+     * Extra duration (in milliseconds) of targetElement to provide visual continuity between the animation and the rendering of the targetElement. Default is 1 second
      */
-    public void setExtraTransitionDuration(double extraTransitionDuration) {
+    public void setExtraTransitionDuration(int extraTransitionDuration) {
         animator.setExtraTransitionDuration(extraTransitionDuration);
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/pathanimator/MaterialPathAnimator.java
+++ b/src/main/java/gwt/material/design/addins/client/pathanimator/MaterialPathAnimator.java
@@ -27,6 +27,7 @@ import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.pathanimator.js.JsPathAnimator;
 import gwt.material.design.addins.client.pathanimator.js.JsPathAnimatorOptions;
 import gwt.material.design.client.MaterialDesignBase;
+import gwt.material.design.client.base.HasDurationTransition;
 import gwt.material.design.jquery.client.api.Functions;
 
 import static gwt.material.design.jquery.client.api.JQuery.$;
@@ -56,7 +57,7 @@ import static gwt.material.design.jquery.client.api.JQuery.$;
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#pathAnimator">Material Path Animator</a>
  */
 //@formatter:on
-public class MaterialPathAnimator {
+public class MaterialPathAnimator implements HasDurationTransition {
 
     static {
         if (MaterialAddins.isDebug()) {
@@ -70,9 +71,9 @@ public class MaterialPathAnimator {
     private Element targetElement;
     private Functions.Func animateCallback;
     private Functions.Func reverseCallback;
-    private double duration = 0.3;
-    private double targetShowDuration = 0;
-    private double extraTransitionDuration = 1;
+    private int duration = 3000;
+    private int targetShowDuration = 0;
+    private int extraTransitionDuration = 1000;
     private JsPathAnimatorOptions options = new JsPathAnimatorOptions();
 
     public MaterialPathAnimator() {
@@ -83,13 +84,9 @@ public class MaterialPathAnimator {
      */
     public void animate() {
         $("document").ready(() -> {
-            options.duration = duration;
-            options.targetShowDuration = targetShowDuration;
-            options.extraTransitionDuration = extraTransitionDuration;
-
-            GWT.log("Duration " + duration);
-            GWT.log("Target Show Duration " + targetShowDuration);
-            GWT.log("Extra Transition Duration " + extraTransitionDuration);
+            options.duration = duration / 1000;
+            options.targetShowDuration = targetShowDuration / 1000;
+            options.extraTransitionDuration = extraTransitionDuration / 1000;
 
             JsPathAnimator.cta(sourceElement, targetElement, options, () -> {
                 if (animateCallback != null) {
@@ -266,36 +263,35 @@ public class MaterialPathAnimator {
         this.reverseCallback = reverseCallback;
     }
 
-    public double getDuration() {
-        return duration;
-    }
-
-    /**
-     * Duration (in seconds) of animation. Default is 0.3 seconds.
-     */
-    public void setDuration(double duration) {
+    @Override
+    public void setDuration(int duration) {
         this.duration = duration;
     }
 
-    public double getTargetShowDuration() {
+    @Override
+    public int getDuration() {
+        return duration;
+    }
+
+    public int getTargetShowDuration() {
         return targetShowDuration;
     }
 
     /**
-     * Duration (in seconds) of targetElement to become visible, if hidden initially. The library will automatically try to figure this out from the element's computed styles. Default is 0 seconds.
+     * Duration (in milliseconds) of targetElement to become visible, if hidden initially. The library will automatically try to figure this out from the element's computed styles. Default is 0 seconds.
      */
-    public void setTargetShowDuration(double targetShowDuration) {
+    public void setTargetShowDuration(int targetShowDuration) {
         this.targetShowDuration = targetShowDuration;
     }
 
-    public double getExtraTransitionDuration() {
+    public int getExtraTransitionDuration() {
         return extraTransitionDuration;
     }
 
     /**
-     * Extra duration (in seconds) of targetElement to provide visual continuity between the animation and the rendering of the targetElement. Default is 1 second
+     * Extra duration (in milliseconds) of targetElement to provide visual continuity between the animation and the rendering of the targetElement. Default is 1 second
      */
-    public void setExtraTransitionDuration(double extraTransitionDuration) {
+    public void setExtraTransitionDuration(int extraTransitionDuration) {
         this.extraTransitionDuration = extraTransitionDuration;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/pathanimator/MaterialPathAnimator.java
+++ b/src/main/java/gwt/material/design/addins/client/pathanimator/MaterialPathAnimator.java
@@ -71,9 +71,9 @@ public class MaterialPathAnimator implements HasDurationTransition {
     private Element targetElement;
     private Functions.Func animateCallback;
     private Functions.Func reverseCallback;
-    private int duration = 3000;
+    private int duration = 300;
     private int targetShowDuration = 0;
-    private int extraTransitionDuration = 1000;
+    private int extraTransitionDuration = 100;
     private JsPathAnimatorOptions options = new JsPathAnimatorOptions();
 
     public MaterialPathAnimator() {

--- a/src/main/java/gwt/material/design/addins/client/popupmenu/MaterialPopupMenu.java
+++ b/src/main/java/gwt/material/design/addins/client/popupmenu/MaterialPopupMenu.java
@@ -63,6 +63,11 @@ public class MaterialPopupMenu extends UnorderedList implements HasSelectionHand
     protected void onLoad() {
         super.onLoad();
 
+        build();
+    }
+
+    @Override
+    protected void build() {
         $(this).attr("tabindex", "0");
         $(this).on("blur", e -> {
             close();

--- a/src/main/java/gwt/material/design/addins/client/sideprofile/MaterialSideProfile.java
+++ b/src/main/java/gwt/material/design/addins/client/sideprofile/MaterialSideProfile.java
@@ -56,6 +56,7 @@ import gwt.material.design.client.constants.CssName;
  * @author kevzlou7979
  * @author Ben Dol
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#!sidenavs">Material Side Profile</a>
+ * @see <a href="https://material.io/guidelines/patterns/navigation-drawer.html">Material Design Specification</a>
  */
 //@formatter:on
 public class MaterialSideProfile extends MaterialWidget implements HasImage {

--- a/src/main/java/gwt/material/design/addins/client/splitpanel/MaterialSplitPanel.java
+++ b/src/main/java/gwt/material/design/addins/client/splitpanel/MaterialSplitPanel.java
@@ -58,6 +58,7 @@ import static gwt.material.design.addins.client.splitpanel.js.JsSplitPanel.$;
  *
  * @author kevzlou7979
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#splitpanel">Split Panel</a>
+ * @see <a href="https://material.io/guidelines/layout/split-screen.html#split-screen-usage">Material Design Specification</a>
  */
 //@formatter:on
 public class MaterialSplitPanel extends MaterialWidget {

--- a/src/main/java/gwt/material/design/addins/client/stepper/MaterialStep.java
+++ b/src/main/java/gwt/material/design/addins/client/stepper/MaterialStep.java
@@ -227,6 +227,30 @@ public class MaterialStep extends MaterialWidget implements HasActive, HasTitle,
         return divBody;
     }
 
+    public Div getConCircle() {
+        return conCircle;
+    }
+
+    public Div getConBody() {
+        return conBody;
+    }
+
+    public Div getDivCircle() {
+        return divCircle;
+    }
+
+    public Div getDivLine() {
+        return divLine;
+    }
+
+    public Div getDivTitle() {
+        return divTitle;
+    }
+
+    public Div getDivDescription() {
+        return divDescription;
+    }
+
     @Override
     public void setAxis(Axis axis) {
         if (axis == null) {

--- a/src/main/java/gwt/material/design/addins/client/stepper/MaterialStep.java
+++ b/src/main/java/gwt/material/design/addins/client/stepper/MaterialStep.java
@@ -93,6 +93,22 @@ public class MaterialStep extends MaterialWidget implements HasActive, HasTitle,
     public MaterialStep() {
         super(Document.get().createDivElement(), AddinsCssName.STEP);
 
+        build();
+    }
+
+    public MaterialStep(String title, String description) {
+        this();
+        setTitle(title);
+        setDescription(description);
+    }
+
+    public MaterialStep(String title, String description, Integer step) {
+        this(title, description);
+        setStep(step);
+    }
+
+    @Override
+    protected void build() {
         super.add(conCircle);
         conCircle.add(divCircle);
         conCircle.add(divLine);
@@ -114,17 +130,6 @@ public class MaterialStep extends MaterialWidget implements HasActive, HasTitle,
         conCircle.addClickHandler(handler);
         divTitle.addClickHandler(handler);
         divDescription.addClickHandler(handler);
-    }
-
-    public MaterialStep(String title, String description) {
-        this();
-        setTitle(title);
-        setDescription(description);
-    }
-
-    public MaterialStep(String title, String description, Integer step) {
-        this(title, description);
-        setStep(step);
     }
 
     @Override

--- a/src/main/java/gwt/material/design/addins/client/stepper/MaterialStep.java
+++ b/src/main/java/gwt/material/design/addins/client/stepper/MaterialStep.java
@@ -63,6 +63,7 @@ import gwt.material.design.client.ui.html.Div;
  *
  * @author kevzlou7979
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#steppers">Material Steppers</a>
+ * @see <a href="https://material.io/guidelines/components/steppers.html">Material Design Specification</a>
  */
 // @formatter:on
 public class MaterialStep extends MaterialWidget implements HasActive, HasTitle, HasError, HasAxis,

--- a/src/main/java/gwt/material/design/addins/client/stepper/MaterialStepper.java
+++ b/src/main/java/gwt/material/design/addins/client/stepper/MaterialStepper.java
@@ -77,6 +77,7 @@ import gwt.material.design.client.ui.html.Span;
  *
  * @author kevzlou7979
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#steppers">Material Steppers</a>
+ * @see <a href="https://material.io/guidelines/components/steppers.html">Material Design Specification</a>
  */
 // @formatter:on
 public class MaterialStepper extends MaterialWidget implements HasAxis, HasError, SelectionHandler<MaterialStep>,

--- a/src/main/java/gwt/material/design/addins/client/stepper/MaterialStepper.java
+++ b/src/main/java/gwt/material/design/addins/client/stepper/MaterialStepper.java
@@ -101,8 +101,8 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
 
     public MaterialStepper() {
         super(Document.get().createDivElement(), AddinsCssName.STEPPER);
-        divFeedback.setStyleName(AddinsCssName.FEEDBACK);
-        divFeedback.add(feedbackSpan);
+
+        build();
     }
 
     @Override
@@ -113,6 +113,12 @@ public class MaterialStepper extends MaterialWidget implements HasAxis, HasError
             StartEvent.fire(MaterialStepper.this);
             goToStep(currentStepIndex + 1);
         }
+    }
+
+    @Override
+    protected void build() {
+        divFeedback.setStyleName(AddinsCssName.FEEDBACK);
+        divFeedback.add(feedbackSpan);
     }
 
     public void setDetectOrientation(boolean detectOrientation) {

--- a/src/main/java/gwt/material/design/addins/client/subheader/MaterialSubHeader.java
+++ b/src/main/java/gwt/material/design/addins/client/subheader/MaterialSubHeader.java
@@ -50,6 +50,7 @@ import gwt.material.design.client.constants.Color;
  *
  * @author kevzlou7979
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#subheaders">Material Subheader</a>
+ * @see <a href="https://material.io/guidelines/components/subheaders.html">Material Design Specification</a>
  */
 //@formatter:on
 public class MaterialSubHeader extends AbstractIconButton {

--- a/src/main/java/gwt/material/design/addins/client/swipeable/MaterialSwipeablePanel.java
+++ b/src/main/java/gwt/material/design/addins/client/swipeable/MaterialSwipeablePanel.java
@@ -94,6 +94,11 @@ public class MaterialSwipeablePanel extends MaterialWidget implements HasSwipeab
     protected void onLoad() {
         super.onLoad();
 
+        build();
+    }
+
+    @Override
+    protected void build() {
         for (Widget w : getChildren()) {
             if (!w.getStyleName().contains(AddinsCssName.IGNORED)) {
                 initSwipeable(w.getElement(), w);

--- a/src/main/java/gwt/material/design/addins/client/timepicker/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/timepicker/MaterialTimePicker.java
@@ -70,6 +70,7 @@ import static gwt.material.design.addins.client.timepicker.js.JsTimePicker.$;
  * @author kevzlou7979
  * @author Ben Dol
  * @see <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/#timepickers">Material Pickers</a>
+ * @see <a href="https://material.io/guidelines/components/pickers.html#pickers-time-pickers">Material Design Specification</a>
  */
 //@formatter:on
 public class MaterialTimePicker extends AbstractValueWidget<Date> implements HasPlaceholder, HasOrientation,

--- a/src/main/java/gwt/material/design/addins/client/timepicker/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/timepicker/MaterialTimePicker.java
@@ -38,7 +38,6 @@ import gwt.material.design.client.base.mixin.ErrorMixin;
 import gwt.material.design.client.base.mixin.ReadOnlyMixin;
 import gwt.material.design.client.base.mixin.ToggleStyleMixin;
 import gwt.material.design.client.constants.*;
-import gwt.material.design.client.js.JsMaterialElement;
 import gwt.material.design.client.js.Window;
 import gwt.material.design.client.ui.MaterialIcon;
 import gwt.material.design.client.ui.MaterialInput;
@@ -89,7 +88,7 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
     /**
      * Wraps the actual input.
      */
-    private MaterialPanel panel = new MaterialPanel();
+    private MaterialPanel container = new MaterialPanel();
 
     /**
      * The input element for the time picker.
@@ -99,19 +98,19 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
     /**
      * Label to display errors messages.
      */
-    private MaterialLabel lblError = new MaterialLabel();
+    private MaterialLabel errorLabel = new MaterialLabel();
 
     /**
      * The current value held by the time picker.
      */
     private Date time;
 
-    private Label lblPlaceholder = new Label();
+    private Label placeholderLabel = new Label();
 
     private MaterialIcon icon = new MaterialIcon();
 
     private ToggleStyleMixin<MaterialInput> validMixin = new ToggleStyleMixin<>(this.timeInput, CssName.VALID);
-    private final ErrorMixin<AbstractValueWidget, MaterialLabel> errorMixin = new ErrorMixin<>(this, lblError, timeInput, lblPlaceholder);
+    private final ErrorMixin<AbstractValueWidget, MaterialLabel> errorMixin = new ErrorMixin<>(this, errorLabel, timeInput, placeholderLabel);
     private ReadOnlyMixin<MaterialTimePicker, MaterialInput> readOnlyMixin;
 
     private String uniqueId;
@@ -150,10 +149,10 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
         uniqueId = DOM.createUniqueId();
         timeInput.setType(InputType.TEXT);
         readOnlyMixin = new ReadOnlyMixin<>(this, timeInput);
-        panel.add(lblPlaceholder);
-        panel.add(timeInput);
-        panel.add(lblError);
-        add(panel);
+        container.add(placeholderLabel);
+        container.add(timeInput);
+        container.add(errorLabel);
+        add(container);
         timeInput.getElement().setAttribute("type", "text");
         initialize();
     }
@@ -217,7 +216,7 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
     @Override
     public void setPlaceholder(String placeholder) {
         this.placeholder = placeholder;
-        lblPlaceholder.setText(placeholder);
+        placeholderLabel.setText(placeholder);
     }
 
     /**
@@ -364,7 +363,7 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
     public void clear() {
         time = null;
         this.clearErrorOrSuccess();
-        lblPlaceholder.removeStyleName(CssName.ACTIVE);
+        placeholderLabel.removeStyleName(CssName.ACTIVE);
         timeInput.removeStyleName(CssName.VALID);
         $(timeInput.getElement()).val("");
     }
@@ -380,8 +379,8 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
         if (this.time == null) {
             return;
         }
-        lblPlaceholder.removeStyleName(CssName.ACTIVE);
-        lblPlaceholder.addStyleName(CssName.ACTIVE);
+        placeholderLabel.removeStyleName(CssName.ACTIVE);
+        placeholderLabel.addStyleName(CssName.ACTIVE);
         $(timeInput.getElement()).val(DateTimeFormat.getFormat(hour24 ? "HH:mm" : "hh:mm aa").format(time));
         super.setValue(time, fireEvents);
     }
@@ -403,8 +402,8 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
     public void setIconType(IconType iconType) {
         icon.setIconType(iconType);
         icon.setIconPrefix(true);
-        lblError.setPaddingLeft(44);
-        panel.insert(icon, 0);
+        errorLabel.setPaddingLeft(44);
+        container.insert(icon, 0);
     }
 
     @Override
@@ -471,5 +470,17 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
 
     public MaterialInput getTimeInput() {
         return timeInput;
+    }
+
+    public MaterialPanel getContainer() {
+        return container;
+    }
+
+    public MaterialLabel getErrorLabel() {
+        return errorLabel;
+    }
+
+    public Label getPlaceholderLabel() {
+        return placeholderLabel;
     }
 }

--- a/src/main/java/gwt/material/design/addins/client/timepicker/MaterialTimePicker.java
+++ b/src/main/java/gwt/material/design/addins/client/timepicker/MaterialTimePicker.java
@@ -141,6 +141,11 @@ public class MaterialTimePicker extends AbstractValueWidget<Date> implements Has
     protected void onLoad() {
         super.onLoad();
 
+        build();
+    }
+
+    @Override
+    protected void build() {
         uniqueId = DOM.createUniqueId();
         timeInput.setType(InputType.TEXT);
         readOnlyMixin = new ReadOnlyMixin<>(this, timeInput);

--- a/src/main/java/gwt/material/design/addins/client/tree/MaterialTree.java
+++ b/src/main/java/gwt/material/design/addins/client/tree/MaterialTree.java
@@ -84,6 +84,11 @@ public class MaterialTree extends MaterialWidget implements HasCloseHandlers<Mat
     protected void onLoad() {
         super.onLoad();
 
+        build();
+    }
+
+    @Override
+    protected void build() {
         // Ensure all children know we are the root.
         for (Widget child : getChildren()) {
             if (child instanceof MaterialTreeItem) {

--- a/src/main/java/gwt/material/design/addins/client/waterfall/MaterialWaterfall.java
+++ b/src/main/java/gwt/material/design/addins/client/waterfall/MaterialWaterfall.java
@@ -88,6 +88,12 @@ public class MaterialWaterfall extends MaterialWidget {
     @Override
     protected void onLoad() {
         super.onLoad();
+
+        build();
+    }
+
+    @Override
+    protected void build() {
         if (openCallback == null) {
             openCallback = () -> {
                 for (Widget w : getChildren()) {

--- a/src/main/java/gwt/material/design/addins/client/window/MaterialWindow.java
+++ b/src/main/java/gwt/material/design/addins/client/window/MaterialWindow.java
@@ -381,6 +381,10 @@ public class MaterialWindow extends MaterialPanel implements HasCloseHandlers<Bo
         return labelTitle;
     }
 
+    public static MaterialPanel getWindowOverlay() {
+        return windowOverlay;
+    }
+
     @Override
     public void setPadding(double padding) {
         content.setPadding(padding);

--- a/src/test/java/gwt/material/design/addins/client/MaterialCutoutTest.java
+++ b/src/test/java/gwt/material/design/addins/client/MaterialCutoutTest.java
@@ -46,7 +46,7 @@ public class MaterialCutoutTest extends MaterialAddinsTest {
     }
 
     protected <T extends MaterialCutOut> void checkProperties(T cutOut) {
-        final String ANIMATION_DURATION = "20s";
+        final int ANIMATION_DURATION = 200;
         final String ANIMATION_TIMING = "linear";
         final String BACKGROUND_SIZE = "100px";
         final int CUTOUT_PADDING = 20;
@@ -54,8 +54,8 @@ public class MaterialCutoutTest extends MaterialAddinsTest {
         assertTrue(cutOut.isAnimated());
         cutOut.setAnimated(false);
         assertFalse(cutOut.isAnimated());
-        cutOut.setAnimationDuration(ANIMATION_DURATION);
-        assertEquals(cutOut.getAnimationDuration(), ANIMATION_DURATION);
+        cutOut.setDuration(ANIMATION_DURATION);
+        assertEquals(cutOut.getDuration(), ANIMATION_DURATION);
         cutOut.setAnimationTimingFunction(ANIMATION_TIMING);
         assertEquals(cutOut.getAnimationTimingFunction(), ANIMATION_TIMING);
         cutOut.setBackgroundSize(BACKGROUND_SIZE);

--- a/src/test/java/gwt/material/design/addins/client/MaterialMasonryTest.java
+++ b/src/test/java/gwt/material/design/addins/client/MaterialMasonryTest.java
@@ -73,8 +73,8 @@ public class MaterialMasonryTest extends MaterialAddinsTest {
         assertTrue(masonry.isOriginTop());
         masonry.setOriginTop(false);
         assertFalse(masonry.isOriginTop());
-        assertEquals(masonry.getTransitionDuration(), Double.valueOf(400));
-        masonry.setTransitionDuration(100);
-        assertEquals(masonry.getTransitionDuration(), Double.valueOf(100));
+        assertEquals(masonry.getDuration(), 400);
+        masonry.setDuration(100);
+        assertEquals(masonry.getDuration(), 100);
     }
 }

--- a/src/test/java/gwt/material/design/addins/client/MaterialPathAnimatorTest.java
+++ b/src/test/java/gwt/material/design/addins/client/MaterialPathAnimatorTest.java
@@ -39,9 +39,9 @@ public class MaterialPathAnimatorTest extends MaterialAddinsTest {
     }
 
     protected void checkProperties() {
-        final double DURATION = 300;
-        final double TARGET_DURATION = 500;
-        final double EXTRA_DURATION = 800;
+        final int DURATION = 300;
+        final int TARGET_DURATION = 500;
+        final int EXTRA_DURATION = 800;
 
         final Functions.Func animateCallback = () -> {};
         final Functions.Func reverseCallback = () -> {};


### PR DESCRIPTION
# Transition Duration
- Refactor all components to have a uniform and configurable transition duration property.
  - MaterialCutOut
  - MaterialIconMorph
  - MaterialMasonry
  - MaterialOverlay
  - MaterialPathAnimator

# Add Links to Material Design Specification
- Provides link for brief information about each component.
- Updated the Demo showcase to have links also refered to Material Design Specification.
_(Demo Ongoing)_

# Added ```build()``` base method to MaterialWidget
- A protected method to build the structure of any complex widget that can be overridden to perform a different behavior of this widget.

# Getter for child widget
- All children widgets of each complex component shall provide a getter for easy customization.