### PR TITLE
Auto Complete Setter to control displayed suggestions

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
+++ b/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
@@ -508,6 +508,18 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
         }
     }
 
+    /**
+     * Set the number of suggestions to be displayed to the user. This differs from
+     * setLimit() which set both the suggestions displayed AND the limit of values
+     * allowed within the autocomplete.
+     * @param limit
+     */
+    public void setAutoSuggestLimit(int limit) {
+        if (this.box != null) {
+            this.box.setLimit(limit);
+        }
+    }
+
     @Override
     public String getPlaceholder() {
         return lblPlaceholder.getText();


### PR DESCRIPTION
Added a setter method that allows the end user to specify the number of suggestions displayed to the end user without changing the value limit