### PR TITLE
Added processQueue and enqueueFile methods to MaterialFileUploader

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -111,6 +111,7 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
     protected JsFileUploaderOptions getDefaultOptions() {
         JsFileUploaderOptions options = new JsFileUploaderOptions();
         options.clickable = "";
+        options.autoProcessQueue = true;
         options.autoQueue = true;
         options.maxFilesize = 20;
         options.maxFiles = 100;
@@ -335,6 +336,19 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
         return new UploadFile(file.name, lastModifiedDate, Double.parseDouble(file.size), file.type);
     }
 
+    /**
+     * Manually start upload queued files when option autoProcessQueue is disabled
+     */
+    public void processQueue() {
+        uploader.processQueue();
+    }
+
+    /**
+     * Manually enqueue file when option autoQueue is disabled
+     */
+    public void enqueueFile(File file) {
+        uploader.enqueueFile(file);
+    }
 
     /**
      * Get the form url.
@@ -362,6 +376,20 @@ public class MaterialFileUploader extends MaterialWidget implements HasFileUploa
      */
     public void setMaxFileSize(int maxFileSize) {
         options.maxFilesize = maxFileSize;
+    }
+
+    /**
+     * Check whether it's auto process queue or not.
+     */
+    public boolean isAutoProcessQueue() {
+        return options.autoProcessQueue;
+    }
+
+    /**
+     * Set the auto process queue boolean value.
+     */
+    public void setAutoProcessQueue(boolean autoProcessQueue) {
+        options.autoProcessQueue = autoProcessQueue;
     }
 
     /**

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/js/Dropzone.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/js/Dropzone.java
@@ -45,4 +45,8 @@ public class Dropzone extends JQueryElement {
     public native void setupEventListeners();
 
     public native void removeAllFiles();
+
+    public native void processQueue();
+
+    public native void enqueueFile(File file);
 }

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/js/JsFileUploaderOptions.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/js/JsFileUploaderOptions.java
@@ -51,6 +51,9 @@ public class JsFileUploaderOptions {
     public String acceptedFiles;
 
     @JsProperty
+    public boolean autoProcessQueue;
+
+    @JsProperty
     public boolean autoQueue;
 
     @JsProperty

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/js/XHR.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/js/XHR.java
@@ -31,4 +31,7 @@ public class XHR {
 
     @JsProperty
     public String statusText;
+
+    @JsProperty
+    public String responseText;
 }

--- a/src/test/java/gwt/material/design/addins/client/MaterialFileUploaderTest.java
+++ b/src/test/java/gwt/material/design/addins/client/MaterialFileUploaderTest.java
@@ -65,6 +65,10 @@ public class MaterialFileUploaderTest extends MaterialAddinsTest {
         assertEquals(fileUploader.getMethod(), FileMethod.POST);
         fileUploader.setMethod(FileMethod.PUT);
         assertEquals(fileUploader.getMethod(), FileMethod.PUT);
+        fileUploader.setAutoProcessQueue(true);
+        assertTrue(fileUploader.isAutoProcessQueue());
+        fileUploader.setAutoProcessQueue(false);
+        assertFalse(fileUploader.isAutoProcessQueue());
         fileUploader.setAutoQueue(true);
         assertTrue(fileUploader.isAutoQueue());
         fileUploader.setAutoQueue(false);


### PR DESCRIPTION
Method processQueue is needed for manually start upload queued files when option autoProcessQueue is disabled.
Method enqueueFile is needed for manually enqueue file when option autoQueue is disabled.