### PR TITLE
Add support for form parameters in file upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,14 @@
             <version>${gwt.version}</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- JsInterop Base -->
+        <dependency>
+			<groupId>com.google.jsinterop</groupId>
+			<artifactId>base</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+        
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/MaterialFileUploader.java
@@ -19,12 +19,17 @@
  */
 package gwt.material.design.addins.client.fileuploader;
 
+import static gwt.material.design.jquery.client.api.JQuery.$;
+
+import java.util.Date;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.DOM;
+
 import gwt.material.design.addins.client.MaterialAddins;
 import gwt.material.design.addins.client.base.constants.AddinsCssName;
 import gwt.material.design.addins.client.dark.AddinsDarkThemeReloader;
@@ -33,7 +38,18 @@ import gwt.material.design.addins.client.fileuploader.base.UploadFile;
 import gwt.material.design.addins.client.fileuploader.base.UploadResponse;
 import gwt.material.design.addins.client.fileuploader.constants.FileMethod;
 import gwt.material.design.addins.client.fileuploader.constants.FileUploaderEvents;
-import gwt.material.design.addins.client.fileuploader.events.*;
+import gwt.material.design.addins.client.fileuploader.events.AddedFileEvent;
+import gwt.material.design.addins.client.fileuploader.events.CanceledEvent;
+import gwt.material.design.addins.client.fileuploader.events.CompleteEvent;
+import gwt.material.design.addins.client.fileuploader.events.CurrentUploadProgressEvent;
+import gwt.material.design.addins.client.fileuploader.events.ErrorEvent;
+import gwt.material.design.addins.client.fileuploader.events.MaxFilesExceededEvent;
+import gwt.material.design.addins.client.fileuploader.events.MaxFilesReachedEvent;
+import gwt.material.design.addins.client.fileuploader.events.RemovedFileEvent;
+import gwt.material.design.addins.client.fileuploader.events.SendingEvent;
+import gwt.material.design.addins.client.fileuploader.events.SuccessEvent;
+import gwt.material.design.addins.client.fileuploader.events.TotalUploadProgressEvent;
+import gwt.material.design.addins.client.fileuploader.events.UnauthorizedEvent;
 import gwt.material.design.addins.client.fileuploader.js.Dropzone;
 import gwt.material.design.addins.client.fileuploader.js.File;
 import gwt.material.design.addins.client.fileuploader.js.JsFileUploaderOptions;
@@ -43,13 +59,15 @@ import gwt.material.design.client.base.JsLoader;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.constants.CssName;
 import gwt.material.design.client.constants.Display;
-import gwt.material.design.client.events.*;
+import gwt.material.design.client.events.DragEndEvent;
+import gwt.material.design.client.events.DragEnterEvent;
+import gwt.material.design.client.events.DragLeaveEvent;
+import gwt.material.design.client.events.DragOverEvent;
+import gwt.material.design.client.events.DragStartEvent;
+import gwt.material.design.client.events.DropEvent;
 import gwt.material.design.client.ui.MaterialToast;
 import gwt.material.design.jquery.client.api.JQueryElement;
-
-import java.util.Date;
-
-import static gwt.material.design.jquery.client.api.JQuery.$;
+import jsinterop.base.JsPropertyMap;
 
 //@formatter:off
 
@@ -503,6 +521,28 @@ public class MaterialFileUploader extends MaterialWidget implements JsLoader, Ha
      */
     public void setAcceptedFiles(String acceptedFiles) {
         options.acceptedFiles = acceptedFiles;
+    }
+    
+    /**
+     * Add a parameter to the upload form. The uploader will have to be reloaded to take effect.
+     * 
+     * @param name
+     * @param value
+     */
+    public void setParam(String name, String value) {
+    	if (options.params == null)
+    		options.params = JsPropertyMap.of();
+    	options.params.set(name, value);
+    }
+    
+    /**
+     * Get the value of the parameter that will be added to the upload form.
+     * 
+     * @param name
+     * @return
+     */
+    public String getParam(String name) {
+    	return (String) options.params.get(name);
     }
 
     public void fireDropEvent() {

--- a/src/main/java/gwt/material/design/addins/client/fileuploader/js/JsFileUploaderOptions.java
+++ b/src/main/java/gwt/material/design/addins/client/fileuploader/js/JsFileUploaderOptions.java
@@ -24,6 +24,7 @@ package gwt.material.design.addins.client.fileuploader.js;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
+import jsinterop.base.JsPropertyMap;
 
 /**
  * Options for file uploader component
@@ -32,7 +33,7 @@ import jsinterop.annotations.JsType;
  */
 @JsType(isNative = true, name = "Object", namespace = JsPackage.GLOBAL)
 public class JsFileUploaderOptions {
-
+	
     public String url;
 
     @JsProperty
@@ -93,4 +94,7 @@ public class JsFileUploaderOptions {
 
     @JsProperty
     public String dictMaxFilesExceeded;
+    
+    @JsProperty
+    public JsPropertyMap<Object> params;
 }

--- a/src/main/resources/gwt/material/design/addins/GwtMaterialAddinsBase.gwt.xml
+++ b/src/main/resources/gwt/material/design/addins/GwtMaterialAddinsBase.gwt.xml
@@ -29,6 +29,9 @@
 
     <inherits name="gwt.material.design.jquery.JQuery"/>
     <inherits name='gwt.material.design.GwtMaterialDesignBase'/>
+    
+    <!-- Required for file uploader -->
+    <inherits name="jsinterop.base.Base" />
 
     <!-- Specify the paths for translatable code                    -->
     <source path='client'/>

--- a/src/test/java/gwt/material/design/addins/client/ui/MaterialFileUploaderTest.java
+++ b/src/test/java/gwt/material/design/addins/client/ui/MaterialFileUploaderTest.java
@@ -100,6 +100,10 @@ public class MaterialFileUploaderTest extends MaterialWidgetTest<MaterialFileUpl
         assertTrue(fileUploader.isWithCredentials());
         fileUploader.setWithCredentials(false);
         assertFalse(fileUploader.isWithCredentials());
+        fileUploader.setParam("name1", "value1");
+        assertEquals("value1", fileUploader.getParam("name1"));
+        fileUploader.setParam("name1", "value2");
+        assertEquals("value2", fileUploader.getParam("name1"));
     }
 
     @Override


### PR DESCRIPTION
I need to be able to add information about an uploaded file using form parameters. Dropzone supports this with the params field in the options, but this wasn't exposed. Because of the relatively complex data structure of a parameter object, I added a dependency to the google jsinterop.base library that allowed me to reference the object as a JsPropertyMap.

To use this, since the options are only set when the Dropzone object is created, after setting the parameters the uploader.reload() function must be called.