### PR TITLE
DateRatePicker: Changed setFirstDay from String to int

### DIFF
--- a/src/main/java/gwt/material/design/incubator/client/daterange/js/DateRangeLocale.java
+++ b/src/main/java/gwt/material/design/incubator/client/daterange/js/DateRangeLocale.java
@@ -67,7 +67,7 @@ public class DateRangeLocale {
     private LocaleString[] monthNames;
 
     @JsProperty
-    private String firstDay;
+    private int firstDay;
 
     @JsOverlay
     public final void setFormat(String format) {
@@ -123,7 +123,7 @@ public class DateRangeLocale {
         }
     }
     @JsOverlay
-    public final void setFirstDay(String firstDay) {
+    public final void setFirstDay(int firstDay) {
         this.firstDay = firstDay;
     }
 }


### PR DESCRIPTION
I changed firstDay ind DateRangeLocale from String to int. So you can choose the first Day of the week in the DateRangePicker Widget.
DateRangeLocale.setFirstDay(1) is Monday.
