### PR TITLE
Clear handler references after unregistering

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
+++ b/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java
@@ -308,8 +308,11 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
 
     protected void unloadHandlers() {
         removeHandler(itemBoxBlurHandler);
+        itemBoxBlurHandler = null;
         removeHandler(itemBoxKeyDownHandler);
+        itemBoxKeyDownHandler = null;
         removeHandler(itemBoxClickHandler);
+        itemBoxClickHandler = null;
     }
 
     /**
@@ -319,6 +322,7 @@ public class MaterialAutoComplete extends AbstractValueWidget<List<? extends Sug
 
         if (itemBoxKeyDownHandler != null) {
             itemBoxKeyDownHandler.removeHandler();
+            itemBoxKeyDownHandler = null;
         }
 
         list.setStyleName(AddinsCssName.MULTIVALUESUGGESTBOX_LIST);


### PR DESCRIPTION
Since [`MaterialAutoComplete.loadHandlers()`](https://github.com/GwtMaterialDesign/gwt-material-addins/blob/ac9836df8f4760463379def8081d6021fe680e38/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java#L234) expect handlers to be `null` to (re)register them, `null`-ify them when unregistering or they won't be re-registered (for example, after invoking [`setup(SuggestOracle)`](https://github.com/GwtMaterialDesign/gwt-material-addins/blob/ac9836df8f4760463379def8081d6021fe680e38/src/main/java/gwt/material/design/addins/client/autocomplete/MaterialAutoComplete.java#L318).