### PR TITLE
Fix for MaterialPopupMenu fires close event on open #425

### DIFF
--- a/src/main/java/gwt/material/design/addins/client/popupmenu/MaterialPopupMenu.java
+++ b/src/main/java/gwt/material/design/addins/client/popupmenu/MaterialPopupMenu.java
@@ -84,7 +84,7 @@ public class MaterialPopupMenu extends UnorderedList implements JsLoader, HasSel
 
         initializeSelectionEvent();
 
-        close();
+        setVisible(false);
     }
 
     @Override


### PR DESCRIPTION
I didn't knew if for some reason the close() in the onLoad Method was required, so I changed it to setVisible false instestead of removing it.